### PR TITLE
Update Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ CFLAGS = $(DIALECT) -W -D_GNU_SOURCE -D_DEFAULT_SOURCE -Wall -Werror -fno-common
 CFLAGS += -DMODES_READSB_VERSION=\"$(READSB_VERSION)\"
 CFLAGS += -Wdate-time -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=2 -fstack-protector-strong -Wformat -Werror=format-security
 
-LIBS = -pthread -lpthread -lm -lrt -lzstd
+LIBS = -pthread -lpthread -lm -lrt -lzstd -lncurses
 
 ifeq ($(ZLIB_STATIC), yes)
 	LIBS += -l:libz.a


### PR DESCRIPTION
added -lncurses to the LIBS in the makefile to include the appropriate libraries. I've received build errors when trying to install via the adsbexchange install scripts on both an Ubuntu and a Debian Linux installation. The build error is related to a missing ncurses library. This pull request resolves the missing library and allows the binaries to compile.

Error Message Attached:

cc -o readsb readsb.o argp.o anet.o interactive.o mode_ac.o mode_s.o comm_b.o json_out.o net_io.o crc.o demod_2400.o uat2esnt/uat2esnt.o uat2esnt/uat_decode.o stats.o cpr.o icao_filter.o track.o util.o fasthash.o convert.o sdr_ifile.o sdr_beast.o sdr.o ais_charset.o globe_index.o geomag.o receiver.o aircraft.o api.o minilzo.o threadpool.o  -pthread -lpthread -lm -lrt -lzstd -lz   
/usr/bin/ld: interactive.o: warning: relocation against `acs_map' in read-only section `.text'
/usr/bin/ld: interactive.o: in function `interactiveInit':
/usr/local/share/adsbexchange/readsb-git/interactive.c:93: undefined reference to `initscr'
/usr/bin/ld: /usr/local/share/adsbexchange/readsb-git/interactive.c:94: undefined reference to `stdscr'
/usr/bin/ld: /usr/local/share/adsbexchange/readsb-git/interactive.c:94: undefined reference to `wclear'
/usr/bin/ld: /usr/local/share/adsbexchange/readsb-git/interactive.c:95: undefined reference to `stdscr'
/usr/bin/ld: interactive.o: in function `interactiveShowData':
/usr/local/share/adsbexchange/readsb-git/interactive.c:137: undefined reference to `stdscr'
/usr/bin/ld: /usr/local/share/adsbexchange/readsb-git/interactive.c:145: undefined reference to `wmove'
/usr/bin/ld: /usr/local/share/adsbexchange/readsb-git/interactive.c:147: undefined reference to `stdscr'
/usr/bin/ld: /usr/local/share/adsbexchange/readsb-git/interactive.c:218: undefined reference to `mvprintw'
/usr/bin/ld: /usr/local/share/adsbexchange/readsb-git/interactive.c:244: undefined reference to `mvprintw'
/usr/bin/ld: /usr/local/share/adsbexchange/readsb-git/interactive.c:262: undefined reference to `stdscr'
/usr/bin/ld: /usr/local/share/adsbexchange/readsb-git/interactive.c:262: undefined reference to `wmove'
/usr/bin/ld: /usr/local/share/adsbexchange/readsb-git/interactive.c:263: undefined reference to `stdscr'
/usr/bin/ld: /usr/local/share/adsbexchange/readsb-git/interactive.c:263: undefined reference to `wclrtobot'
/usr/bin/ld: /usr/local/share/adsbexchange/readsb-git/interactive.c:264: undefined reference to `stdscr'
/usr/bin/ld: /usr/local/share/adsbexchange/readsb-git/interactive.c:145: undefined reference to `stdscr'
/usr/bin/ld: /usr/local/share/adsbexchange/readsb-git/interactive.c:145: undefined reference to `waddch'
/usr/bin/ld: /usr/local/share/adsbexchange/readsb-git/interactive.c:137: undefined reference to `wclear'
/usr/bin/ld: /usr/local/share/adsbexchange/readsb-git/interactive.c:139: undefined reference to `mvprintw'
/usr/bin/ld: /usr/local/share/adsbexchange/readsb-git/interactive.c:140: undefined reference to `stdscr'
/usr/bin/ld: /usr/local/share/adsbexchange/readsb-git/interactive.c:140: undefined reference to `wmove'
/usr/bin/ld: /usr/local/share/adsbexchange/readsb-git/interactive.c:145: undefined reference to `stdscr'
/usr/bin/ld: /usr/local/share/adsbexchange/readsb-git/interactive.c:140: undefined reference to `stdscr'
/usr/bin/ld: /usr/local/share/adsbexchange/readsb-git/interactive.c:140: undefined reference to `acs_map'
/usr/bin/ld: /usr/local/share/adsbexchange/readsb-git/interactive.c:140: undefined reference to `whline'
/usr/bin/ld: /usr/local/share/adsbexchange/readsb-git/interactive.c:145: undefined reference to `stdscr'
/usr/bin/ld: interactive.o: in function `interactiveInit':
/usr/local/share/adsbexchange/readsb-git/interactive.c:95: undefined reference to `wrefresh'
/usr/bin/ld: interactive.o: in function `interactiveCleanup':
/usr/local/share/adsbexchange/readsb-git/interactive.c:101: undefined reference to `endwin'
/usr/bin/ld: interactive.o: in function `interactiveShowData':
/usr/local/share/adsbexchange/readsb-git/interactive.c:264: undefined reference to `wrefresh'