### PR TITLE
Fix: Increase spinner array size for GCC 14/15 compatibility

### DIFF
--- a/interactive.c
+++ b/interactive.c
@@ -123,7 +123,7 @@ void interactiveShowData(void) {
     static int64_t next_clear;
     int64_t now = mstime();
     char progress;
-    char spinner[4] = "|/-\\";
+    char spinner[5] = "|/-\\";
 
     // Refresh screen every (MODES_INTERACTIVE_REFRESH_TIME) miliseconde
     if (now < next_update)


### PR DESCRIPTION
PR fixes a compilation error on newer Linux distributions using GCC 14 or 15.

The spinner array was initialized with 4 characters, but the array size was explicitly set to [4]. Modern GCC versions treat this as a fatal error because there is no room for the null terminator (\0), and the build dies.

Increasing the array size from 4 to 5 to accommodate the null terminator allows the build to complete on modern systems.