### PR TITLE
Fix: resolve build errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,7 @@ oneoff/decode_comm_b
 readsb
 viewadsb
 .version
+crctests
+cprtests
+debian/
+.idea/

--- a/Makefile
+++ b/Makefile
@@ -133,6 +133,8 @@ endif
 # add custom overrides if user defines them
 CFLAGS += -g $(OPTIMIZE)
 
+.PHONY: clean test cprtest crctest
+
 all: readsb viewadsb
 
 ifneq ($(shell cat .version 2>/dev/null),prefix $(READSB_VERSION))
@@ -164,11 +166,16 @@ viewadsb: readsb
 clean:
 	rm -f *.o uat2esnt/*.o compat/clock_gettime/*.o compat/clock_nanosleep/*.o readsb viewadsb cprtests crctests convert_benchmark
 
+test: cprtest crctest
+
 cprtest: cprtests
 	./cprtests
 
 cprtests: cpr.o cprtests.o
 	$(CC) $(CFLAGS) -o $@ $^ -lm
+
+crctest: crctests
+	./crctests 1 1
 
 crctests: crc.c crc.h
 	$(CC) $(CFLAGS) -DCRCDEBUG -o $@ $<

--- a/ais_charset.c
+++ b/ais_charset.c
@@ -23,4 +23,4 @@
 
 #include "ais_charset.h"
 
-char ais_charset[64] = "@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_ !\"#$%&'()*+,-./0123456789:;<=>?";
+char ais_charset[] = "@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_ !\"#$%&'()*+,-./0123456789:;<=>?";

--- a/ais_charset.h
+++ b/ais_charset.h
@@ -24,6 +24,6 @@
 #ifndef AIS_CHARSET_H
 #define AIS_CHARSET_H
 
-extern char ais_charset[64];
+extern char ais_charset[];
 
 #endif

--- a/crc.c
+++ b/crc.c
@@ -24,6 +24,13 @@
 #include "readsb.h"
 #include <assert.h>
 
+#ifdef CRCDEBUG
+void setExit(int) {
+    return;
+}
+#endif
+
+
 // Errorinfo for "no errors"
 static struct errorinfo NO_ERRORS;
 

--- a/geomag.c
+++ b/geomag.c
@@ -475,7 +475,6 @@ static char geomag_introduction(double epochlowlim)
     char help;
     static char ans;
     int res = 0;
-    res++;
 
     printf("\n\n Welcome to the World Magnetic Model (WMM) %4.0lf C-Program\n\n", epochlowlim);
     printf("            --- Version 3.0, January 2010 ---\n\n");
@@ -484,6 +483,10 @@ static char geomag_introduction(double epochlowlim)
     printf("\n Enter h for help and contact information or c to continue.");
     printf ("\n >");
     res = scanf("%c%*[^\n]",&help);
+    if (res <= 0) {
+        // reading from stdin didn't work
+        exit(1);
+    }
     getchar();
 
     if ((help == 'h') || (help == 'H'))
@@ -567,7 +570,6 @@ void geomag_interactive() {
     double epochrange = 5.0;
     double dmin, imin, ddeg, ideg;
     int res = 0;
-    res++;
 
     char ans = geomag_introduction(epochlowlim);
     if ((ans == 'y') || (ans == 'Y'))
@@ -581,10 +583,16 @@ S1:
     warn_H_strong_val = 99999.0;
     warn_P = 0;
 
-    printf("\n\n\nENTER LATITUDE IN DECIMAL DEGREES ");
-    printf("\n(North latitude positive, South latitude negative \n");
-    printf("i.e. 25.5 for 25 degrees 30 minutes north.) \n");
-    res = scanf("%lf%*[^\n]", &dlat);
+    while (res <= 0 ) {
+        printf("\n\n\nENTER LATITUDE IN DECIMAL DEGREES ");
+        printf("\n(North latitude positive, South latitude negative \n");
+        printf("i.e. 25.5 for 25 degrees 30 minutes north.) \n");
+        res = scanf("%lf%*[^\n]", &dlat);
+        if (res <= 0) {
+            printf("Invalid input. Please try again.");
+        }
+    }
+
     getchar();
 
     printf("ENTER LONGITUDE IN DECIMAL DEGREES");

--- a/globe_index.c
+++ b/globe_index.c
@@ -1114,7 +1114,6 @@ static void mark_legs(traceBuffer tb, struct aircraft *a, int start, int recent)
     int64_t last_high = 0;
     int64_t last_low = 0;
 
-    int last_high_index = 0;
     int last_low_index = 0;
 
     int64_t last_airborne = 0;
@@ -1125,7 +1124,6 @@ static void mark_legs(traceBuffer tb, struct aircraft *a, int start, int recent)
 
     int last_5min_gap_index = -1;
     struct state last_5min_gap_state = { 0 };
-    int last_10min_gap_index = -1;
 
     int was_ground = 0;
 
@@ -1166,10 +1164,6 @@ static void mark_legs(traceBuffer tb, struct aircraft *a, int start, int recent)
             last_5min_gap_state = *state;
             if (focus) {
                 fprintf(stderr, "5 min gap detected with index %d\n", state_index);
-            }
-            if (elapsed > 10 * MINUTES) {
-                last_10min_gap_index++; // shut up unused var
-                last_10min_gap_index = state_index;
             }
         }
 
@@ -1231,7 +1225,6 @@ static void mark_legs(traceBuffer tb, struct aircraft *a, int start, int recent)
             // fake major_climb after takeoff ... bit hacky
             high = low + threshold + 1;
             last_high = state->timestamp;
-            last_high_index = index;
             last_low = last_ground;
             last_low_index = last_ground_index;
         }
@@ -1245,8 +1238,6 @@ static void mark_legs(traceBuffer tb, struct aircraft *a, int start, int recent)
         }
         if (abs(high - altitude) < threshold * 1 / 3) {
             last_high = state->timestamp;
-            last_high_index++;
-            last_high_index = index;
             if (0 && focus) {
                 time_t nowish = state->timestamp/1000;
                 struct tm utc;

--- a/interactive.c
+++ b/interactive.c
@@ -123,7 +123,7 @@ void interactiveShowData(void) {
     static int64_t next_clear;
     int64_t now = mstime();
     char progress;
-    char spinner[4] = "|/-\\";
+    char spinner[] = "|/-\\";
 
     // Refresh screen every (MODES_INTERACTIVE_REFRESH_TIME) miliseconde
     if (now < next_update)

--- a/uat2esnt/uat_decode.c
+++ b/uat2esnt/uat_decode.c
@@ -267,7 +267,7 @@ static void uat_display_sv(const struct uat_adsb_mdb *mdb, FILE *to)
             mdb->tisb_site_id);
 }
 
-static char base40_alphabet[40] = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ  ..";
+static char base40_alphabet[] = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ  ..";
 static void uat_decode_ms(uint8_t *frame, struct uat_adsb_mdb *mdb)
 {
     uint16_t v;


### PR DESCRIPTION
The initial motivation for this PR was to resolve compiler warnings, which are promoted to errors, which cause the build to fail. I ended up also fixing a couple issues with some of the tests (other issues still remain).

- (gcc) Strings in `ais_charset.c`, `interactive.c`, and `uat_decode.c` had character arrays initialized without a null terminator. GCC's [proposed fix](https://gcc.gnu.org/onlinedocs/gcc-15.2.0/gcc/Warning-Options.html#index-Wno-unterminated-string-initialization) is not portable to clang, so I've removed the hard-coded array length. Both compilers seem to be satisfied with this. (See also, #10)
- (clang) The value of `res` in `geomag.c` was not being used. I've added appropriate checks to use the value as intended.
- (clang) Certain variables in `globe_index.c` were being written, but never read. I've removed the lines of code in question.
- The CRC tests were failing due to the `setExit` symbol being missing, so I've added a stubbed version for the tests.
- Small changes to the `Makefile` for ergonomics

Tested on the following setup:
```
$ cat /etc/lsb-release 
DISTRIB_ID=Ubuntu
DISTRIB_RELEASE=25.10
DISTRIB_CODENAME=questing
DISTRIB_DESCRIPTION="Ubuntu 25.10"

$ gcc --version
gcc (Ubuntu 15.2.0-4ubuntu4) 15.2.0
Copyright (C) 2025 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

$ clang --version
Ubuntu clang version 20.1.8 (0ubuntu4)
Target: x86_64-pc-linux-gnu
Thread model: posix
InstalledDir: /usr/lib/llvm-20/bin
```

Full disclosures: 
- C is not my strongest language
- This PR does not contain AI-generated code
