### PR TITLE
AX-936: upstream-sync triage tooling + integration test coverage (90→130)

### DIFF
--- a/tests/TEST_COVERAGE.md
+++ b/tests/TEST_COVERAGE.md
@@ -1,6 +1,6 @@
 # readsb Test Coverage Reference
 
-Last updated: 2026-02-27
+Last updated: 2026-06-24
 
 ## Summary
 
@@ -8,8 +8,8 @@ Last updated: 2026-02-27
 |----------|-------|
 | Unit test binaries | 22 |
 | Unit test functions | ~215 |
-| Integration test files | 13 |
-| Integration test functions | 90 |
+| Integration test files | 14 |
+| Integration test functions | 96 |
 
 ## Unit Tests
 
@@ -101,6 +101,7 @@ Integration tests use Python 3 unittest, spawning a real readsb process per test
 | `test_uav.py` | TestUav, TestUavApi, TestUavRejected, TestUavFilterApi | 11 | UAV/drone support, API queries, --enable-uav gate, filter_uav with db |
 | `test_net_connector.py` | TestBeastDF17Input, TestMultiSource | 5 | Beast DF17 position, multi-source (SBS+Beast) |
 | `test_stats_and_history.py` | TestReceiverJson, TestJsonFileWriting | 9 | receiver.json, aircraft.json, file updates, message counts |
+| `test_globe_index.py` | TestGlobeIndex, TestGlobeIndexDisabled | 6 | globe_*.json tiles (gzip), tile schema + bbox placement, receiver.json globeIndexGrid/SpecialTiles; negative control without the flag |
 
 Run all integration tests: `make inttest`
 Run everything: `make fulltest`

--- a/tests/TEST_COVERAGE.md
+++ b/tests/TEST_COVERAGE.md
@@ -8,8 +8,8 @@ Last updated: 2026-06-24
 |----------|-------|
 | Unit test binaries | 22 |
 | Unit test functions | ~215 |
-| Integration test files | 19 |
-| Integration test functions | 113 |
+| Integration test files | 21 |
+| Integration test functions | 119 |
 
 ## Unit Tests
 
@@ -107,6 +107,8 @@ Integration tests use Python 3 unittest, spawning a real readsb process per test
 | `test_receiver_json.py` | TestReceiverJsonFields | 3 | receiver.json capability fields: version/refresh/history, binCraft/zstd/json_trace_interval, globeIndexGrid + globeIndexSpecialTiles |
 | `test_aircraft_json_fields.py` | TestAircraftJsonFields | 4 | aircraft.json top-level shape + per-aircraft object field/type contract (hex/flight/lat/lon/alt_baro/gs/track/seen/rssi/squawk/type, mlat/tisb arrays) |
 | `test_globe_history.py` | TestGlobeHistory | 3 | --write-globe-history dated YYYY/MM/DD layout (traces/ + acas/), internal_state/ blobs (heatmap.bin is day-rollover-gated, not asserted) |
+| `test_state_persistence.py` | TestStatePersistence | 3 | --write-state round-trip: state blobs on exit, aircraft + position restored after restart (guards re-api state drift) |
+| `test_json_out_stream.py` | TestJsonOutStream | 3 | --net-json-port streaming record (EKS→Vector→MSK): JSON object per position, hex/lat/lon/alt_baro + streaming fields |
 
 Run all integration tests: `make inttest`
 Run everything: `make fulltest`

--- a/tests/TEST_COVERAGE.md
+++ b/tests/TEST_COVERAGE.md
@@ -8,8 +8,8 @@ Last updated: 2026-06-24
 |----------|-------|
 | Unit test binaries | 22 |
 | Unit test functions | ~215 |
-| Integration test files | 15 |
-| Integration test functions | 100 |
+| Integration test files | 16 |
+| Integration test functions | 103 |
 
 ## Unit Tests
 
@@ -103,6 +103,7 @@ Integration tests use Python 3 unittest, spawning a real readsb process per test
 | `test_stats_and_history.py` | TestReceiverJson, TestJsonFileWriting | 9 | receiver.json, aircraft.json, file updates, message counts |
 | `test_globe_index.py` | TestGlobeIndex, TestGlobeIndexDisabled | 6 | globe_*.json tiles (gzip), tile schema + bbox placement, receiver.json globeIndexGrid/SpecialTiles; negative control without the flag |
 | `test_trace_files.py` | TestTraceFiles | 4 | trace_recent/full_<icao>.json (gzip) under traces/<last2hex>/, root {icao,timestamp,trace[]}, fixed 14-element trace-point array contract |
+| `test_clients_json.py` | TestClientsJson | 3 | clients.json (--net-ingest): {now,format[],clients[]}, format header contract, positional client-row arity (leaderboard ingest contract) |
 
 Run all integration tests: `make inttest`
 Run everything: `make fulltest`

--- a/tests/TEST_COVERAGE.md
+++ b/tests/TEST_COVERAGE.md
@@ -8,8 +8,8 @@ Last updated: 2026-06-24
 |----------|-------|
 | Unit test binaries | 22 |
 | Unit test functions | ~215 |
-| Integration test files | 22 |
-| Integration test functions | 124 |
+| Integration test files | 24 |
+| Integration test functions | 130 |
 
 ## Unit Tests
 
@@ -110,6 +110,8 @@ Integration tests use Python 3 unittest, spawning a real readsb process per test
 | `test_state_persistence.py` | TestStatePersistence | 3 | --write-state round-trip: state blobs on exit, aircraft + position restored after restart (guards re-api state drift) |
 | `test_json_out_stream.py` | TestJsonOutStream | 3 | --net-json-port streaming record (EKS→Vector→MSK): JSON object per position, hex/lat/lon/alt_baro + streaming fields |
 | `test_db_enrichment.py` | TestDbEnrichment | 5 | --db-file enrichment (r/t/dbFlags + desc via --db-file-lt), military bit (bit0), civil non-mil, hardcoded mil address range. Note: rows need trailing ';' + db >1000 bytes |
+| `test_output_files_extra.py` | TestExtraOutputFiles | 4 | --write-json-gzip (aircraft.json.gz valid + matches plain) and --write-prom (readsb_ Prometheus metrics, valid format; node_exporter contract) |
+| `test_trace_hist_only.py` | TestTraceHistOnly | 2 | --json-trace-hist-only 3 suppresses /run trace files (hrtraces/globe-history mode); aircraft still tracked |
 
 Run all integration tests: `make inttest`
 Run everything: `make fulltest`

--- a/tests/TEST_COVERAGE.md
+++ b/tests/TEST_COVERAGE.md
@@ -8,8 +8,8 @@ Last updated: 2026-06-24
 |----------|-------|
 | Unit test binaries | 22 |
 | Unit test functions | ~215 |
-| Integration test files | 21 |
-| Integration test functions | 119 |
+| Integration test files | 22 |
+| Integration test functions | 124 |
 
 ## Unit Tests
 
@@ -109,6 +109,7 @@ Integration tests use Python 3 unittest, spawning a real readsb process per test
 | `test_globe_history.py` | TestGlobeHistory | 3 | --write-globe-history dated YYYY/MM/DD layout (traces/ + acas/), internal_state/ blobs (heatmap.bin is day-rollover-gated, not asserted) |
 | `test_state_persistence.py` | TestStatePersistence | 3 | --write-state round-trip: state blobs on exit, aircraft + position restored after restart (guards re-api state drift) |
 | `test_json_out_stream.py` | TestJsonOutStream | 3 | --net-json-port streaming record (EKS→Vector→MSK): JSON object per position, hex/lat/lon/alt_baro + streaming fields |
+| `test_db_enrichment.py` | TestDbEnrichment | 5 | --db-file enrichment (r/t/dbFlags + desc via --db-file-lt), military bit (bit0), civil non-mil, hardcoded mil address range. Note: rows need trailing ';' + db >1000 bytes |
 
 Run all integration tests: `make inttest`
 Run everything: `make fulltest`

--- a/tests/TEST_COVERAGE.md
+++ b/tests/TEST_COVERAGE.md
@@ -8,8 +8,8 @@ Last updated: 2026-06-24
 |----------|-------|
 | Unit test binaries | 22 |
 | Unit test functions | ~215 |
-| Integration test files | 14 |
-| Integration test functions | 96 |
+| Integration test files | 15 |
+| Integration test functions | 100 |
 
 ## Unit Tests
 
@@ -102,6 +102,7 @@ Integration tests use Python 3 unittest, spawning a real readsb process per test
 | `test_net_connector.py` | TestBeastDF17Input, TestMultiSource | 5 | Beast DF17 position, multi-source (SBS+Beast) |
 | `test_stats_and_history.py` | TestReceiverJson, TestJsonFileWriting | 9 | receiver.json, aircraft.json, file updates, message counts |
 | `test_globe_index.py` | TestGlobeIndex, TestGlobeIndexDisabled | 6 | globe_*.json tiles (gzip), tile schema + bbox placement, receiver.json globeIndexGrid/SpecialTiles; negative control without the flag |
+| `test_trace_files.py` | TestTraceFiles | 4 | trace_recent/full_<icao>.json (gzip) under traces/<last2hex>/, root {icao,timestamp,trace[]}, fixed 14-element trace-point array contract |
 
 Run all integration tests: `make inttest`
 Run everything: `make fulltest`

--- a/tests/TEST_COVERAGE.md
+++ b/tests/TEST_COVERAGE.md
@@ -8,8 +8,8 @@ Last updated: 2026-06-24
 |----------|-------|
 | Unit test binaries | 22 |
 | Unit test functions | ~215 |
-| Integration test files | 18 |
-| Integration test functions | 110 |
+| Integration test files | 19 |
+| Integration test functions | 113 |
 
 ## Unit Tests
 
@@ -106,6 +106,7 @@ Integration tests use Python 3 unittest, spawning a real readsb process per test
 | `test_clients_json.py` | TestClientsJson | 3 | clients.json (--net-ingest): {now,format[],clients[]}, format header contract, positional client-row arity (leaderboard ingest contract) |
 | `test_receiver_json.py` | TestReceiverJsonFields | 3 | receiver.json capability fields: version/refresh/history, binCraft/zstd/json_trace_interval, globeIndexGrid + globeIndexSpecialTiles |
 | `test_aircraft_json_fields.py` | TestAircraftJsonFields | 4 | aircraft.json top-level shape + per-aircraft object field/type contract (hex/flight/lat/lon/alt_baro/gs/track/seen/rssi/squawk/type, mlat/tisb arrays) |
+| `test_globe_history.py` | TestGlobeHistory | 3 | --write-globe-history dated YYYY/MM/DD layout (traces/ + acas/), internal_state/ blobs (heatmap.bin is day-rollover-gated, not asserted) |
 
 Run all integration tests: `make inttest`
 Run everything: `make fulltest`

--- a/tests/TEST_COVERAGE.md
+++ b/tests/TEST_COVERAGE.md
@@ -8,8 +8,8 @@ Last updated: 2026-06-24
 |----------|-------|
 | Unit test binaries | 22 |
 | Unit test functions | ~215 |
-| Integration test files | 16 |
-| Integration test functions | 103 |
+| Integration test files | 18 |
+| Integration test functions | 110 |
 
 ## Unit Tests
 
@@ -104,6 +104,8 @@ Integration tests use Python 3 unittest, spawning a real readsb process per test
 | `test_globe_index.py` | TestGlobeIndex, TestGlobeIndexDisabled | 6 | globe_*.json tiles (gzip), tile schema + bbox placement, receiver.json globeIndexGrid/SpecialTiles; negative control without the flag |
 | `test_trace_files.py` | TestTraceFiles | 4 | trace_recent/full_<icao>.json (gzip) under traces/<last2hex>/, root {icao,timestamp,trace[]}, fixed 14-element trace-point array contract |
 | `test_clients_json.py` | TestClientsJson | 3 | clients.json (--net-ingest): {now,format[],clients[]}, format header contract, positional client-row arity (leaderboard ingest contract) |
+| `test_receiver_json.py` | TestReceiverJsonFields | 3 | receiver.json capability fields: version/refresh/history, binCraft/zstd/json_trace_interval, globeIndexGrid + globeIndexSpecialTiles |
+| `test_aircraft_json_fields.py` | TestAircraftJsonFields | 4 | aircraft.json top-level shape + per-aircraft object field/type contract (hex/flight/lat/lon/alt_baro/gs/track/seen/rssi/squawk/type, mlat/tisb arrays) |
 
 Run all integration tests: `make inttest`
 Run everything: `make fulltest`

--- a/tests/test_aircraft_json_fields.py
+++ b/tests/test_aircraft_json_fields.py
@@ -1,0 +1,104 @@
+"""
+aircraft.json field-stability integration test.
+
+aircraft.json is parsed by three consumers (tar1090, leaderboard, exporters).
+This pins the top-level shape and the high-value per-aircraft object fields +
+types that 3.14.1631 emits, so the reconciliation walk flags a field
+rename/retype/removal at the commit that introduces it.
+
+(Each aircraft is a JSON object — the positional array layout is binCraft-only,
+not the JSON output.)
+"""
+
+import json
+import time
+import unittest
+from pathlib import Path
+
+from conftest import (
+    ReadsbInstance, feed_sbs, poll_aircraft_json,
+    sbs_msg1, sbs_msg3, sbs_msg4, sbs_msg6,
+)
+
+
+class TestAircraftJsonFields(unittest.TestCase):
+    """Top-level shape + per-aircraft object field contract."""
+
+    HEX = "abc123"
+
+    @classmethod
+    def setUpClass(cls):
+        cls.inst = ReadsbInstance()
+        cls.inst.__enter__()
+        sock = cls.inst.feeder()
+        # Rich feed: callsign + position + velocity + squawk, so the high-value
+        # fields are populated.
+        for _ in range(8):
+            feed_sbs(sock, [
+                sbs_msg1(cls.HEX, "TEST123 "),
+                sbs_msg3(cls.HEX, alt=35000, lat=51.5, lon=-0.1),
+                sbs_msg4(cls.HEX, gs=450, track=90, vr=64),
+                sbs_msg6(cls.HEX, squawk="1200"),
+            ])
+            time.sleep(0.3)
+        # Poll until the entry actually carries a position — the hex can appear
+        # (from the callsign message) a write-cycle before lat/lon land.
+        cls.data = None
+        deadline = time.monotonic() + 8
+        while time.monotonic() < deadline:
+            d = poll_aircraft_json(cls.inst.tmpdir, timeout=2, want_hex=cls.HEX)
+            ac = next((a for a in d["aircraft"] if a.get("hex") == cls.HEX), None) if d else None
+            if ac and "lat" in ac:
+                cls.data = d
+                break
+            time.sleep(0.3)
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.inst.__exit__(None, None, None)
+
+    def _aircraft(self):
+        self.assertIsNotNone(self.data, "aircraft.json never appeared with our hex")
+        ac = next((a for a in self.data["aircraft"] if a.get("hex") == self.HEX), None)
+        self.assertIsNotNone(ac, f"{self.HEX} not in aircraft.json")
+        return ac
+
+    def test_a1_top_level_shape(self):
+        """aircraft.json top-level is {now, messages, aircraft[]}."""
+        self.assertIsNotNone(self.data)
+        self.assertIsInstance(self.data.get("now"), (int, float))
+        self.assertIsInstance(self.data.get("messages"), (int, float))
+        self.assertIsInstance(self.data.get("aircraft"), list)
+
+    def test_a2_aircraft_entries_are_objects(self):
+        """Each aircraft entry is a JSON object keyed by hex."""
+        ac = self._aircraft()
+        self.assertIsInstance(ac, dict)
+        self.assertIsInstance(ac["hex"], str)
+
+    def test_a3_high_value_fields_and_types(self):
+        """The fields the three consumers parse are present and correctly typed."""
+        ac = self._aircraft()
+        self.assertIsInstance(ac.get("flight"), str)
+        self.assertIsInstance(ac.get("lat"), (int, float))
+        self.assertIsInstance(ac.get("lon"), (int, float))
+        # alt_baro is numeric in flight, or the string "ground"
+        self.assertIsInstance(ac.get("alt_baro"), (int, float, str))
+        self.assertIsInstance(ac.get("gs"), (int, float))
+        self.assertIsInstance(ac.get("track"), (int, float))
+        self.assertIsInstance(ac.get("seen"), (int, float))
+        self.assertIsInstance(ac.get("seen_pos"), (int, float))
+        self.assertIsInstance(ac.get("rssi"), (int, float))
+        self.assertIsInstance(ac.get("messages"), (int, float))
+        self.assertIsInstance(ac.get("squawk"), str)
+        self.assertIsInstance(ac.get("type"), str)
+
+    def test_a4_list_fields_are_arrays(self):
+        """mlat / tisb are arrays (tar1090 iterates them)."""
+        ac = self._aircraft()
+        self.assertIsInstance(ac.get("mlat"), list)
+        self.assertIsInstance(ac.get("tisb"), list)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/test_clients_json.py
+++ b/tests/test_clients_json.py
@@ -1,0 +1,105 @@
+"""
+clients.json format integration test (--net-ingest).
+
+An ingest node (the prod `beast` role) writes clients.json listing connected
+feeders. The leaderboard parses it by position, so the `format[]` header and the
+arity of each positional client row are a hard contract — a reordered or added
+column silently corrupts feeder stats. This pins both against the 3.14.1631
+baseline.
+
+Root: {now, format[], clients[]}. Each client row (positional, len == format):
+  [0] receiverId (uuid)      [5] positions/s
+  [1] host:port              [6] reduce_signal
+  [2] avg. kbit/s            [7] recent_rtt(ms)  (-1 = none)
+  [3] conn time(s)           [8] positions
+  [4] messages/s
+"""
+
+import json
+import socket
+import time
+import unittest
+from pathlib import Path
+
+from conftest import ReadsbInstance, beast_frame, make_df17_position, wait_for_port
+
+# The clients.json column header for readsb 3.14.1631 (leaderboard ingest
+# contract). A change here breaks leaderboard feeder stats — treat as a gate.
+EXPECTED_FORMAT = [
+    "receiverId", "host:port", "avg. kbit/s", "conn time(s)", "messages/s",
+    "positions/s", "reduce_signal", "recent_rtt(ms)", "positions",
+]
+
+
+def poll_clients_json(json_dir, timeout=10, min_clients=1):
+    """Poll until clients.json exists with at least *min_clients* entries."""
+    path = Path(json_dir) / "clients.json"
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if path.exists():
+            try:
+                data = json.loads(path.read_text())
+                if len(data.get("clients", [])) >= min_clients:
+                    return data
+            except (json.JSONDecodeError, OSError):
+                pass
+        time.sleep(0.3)
+    return None
+
+
+class TestClientsJson(unittest.TestCase):
+    """clients.json header + positional row contract with a connected feeder."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.inst = ReadsbInstance(beast_in=True, extra_args=["--net-ingest"])
+        cls.inst.__enter__()
+        wait_for_port(cls.inst.beast_in_port)
+        # Persistent beast feeder — clients.json only lists *active* connections,
+        # so the socket stays open until tearDownClass.
+        cls.client = socket.create_connection(
+            ("127.0.0.1", cls.inst.beast_in_port), timeout=5)
+        for _ in range(20):
+            cls.client.sendall(
+                beast_frame(make_df17_position("ABC123", 51.5, -0.1, 35000, 0))
+                + beast_frame(make_df17_position("ABC123", 51.5, -0.1, 35000, 1)))
+            time.sleep(0.3)
+        cls.data = poll_clients_json(cls.inst.tmpdir, timeout=10, min_clients=1)
+
+    @classmethod
+    def tearDownClass(cls):
+        try:
+            cls.client.close()
+        except Exception:
+            pass
+        cls.inst.__exit__(None, None, None)
+
+    def test_c1_clients_json_structure(self):
+        """clients.json is written with {now, format, clients}."""
+        self.assertIsNotNone(self.data, "clients.json never had a client entry")
+        self.assertIn("now", self.data)
+        self.assertIsInstance(self.data["now"], (int, float))
+        self.assertIn("format", self.data)
+        self.assertIn("clients", self.data)
+        self.assertIsInstance(self.data["clients"], list)
+
+    def test_c2_format_header_contract(self):
+        """The format[] column header matches the leaderboard-parsed contract."""
+        self.assertEqual(self.data["format"], EXPECTED_FORMAT,
+                         "clients.json column header changed — leaderboard parses "
+                         "by position, so this breaks feeder stats")
+
+    def test_c3_client_row_is_positional_and_matches_format(self):
+        """Each client row has the same arity as format; key fields typed right."""
+        self.assertGreater(len(self.data["clients"]), 0, "no connected clients")
+        row = self.data["clients"][0]
+        self.assertIsInstance(row, list)
+        self.assertEqual(len(row), len(self.data["format"]),
+                         "client row arity must match the format[] header")
+        self.assertIsInstance(row[0], str)   # [0] receiverId (uuid)
+        self.assertIsInstance(row[1], str)   # [1] host:port
+        self.assertIn("port", row[1])
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/test_db_enrichment.py
+++ b/tests/test_db_enrichment.py
@@ -1,0 +1,147 @@
+"""
+Aircraft-DB enrichment + military classification integration test (--db-file).
+
+readsb enriches aircraft from a tar1090-db CSV (--db-file): registration (r),
+type code (t), and dbFlags (bit 0 = military). tar1090 shows reg/type;
+the leaderboard + globeMil tiles use the military bit. With --db-file-lt the
+long description (desc), ownOp, and year are also emitted.
+
+Two things to know about the format (learned the hard way):
+  * the decompressed CSV must be > 1000 bytes or readsb rejects it
+    (aircraft.c: "database file very small, bailing out");
+  * every field is ';'-delimited INCLUDING the last, so each row needs a
+    TRAILING ';' or the row is silently skipped before being indexed.
+Rows: addr;registration;typeCode;dbFlagBits;typeLong;year;ownOp;
+dbFlagBits is a '0'/'1' string, bit 0 (first char) = military.
+
+readsb also classifies known military address ranges with no db entry (e.g.
+German mil 0x3EA000-0x3EBFFF), but that only surfaces in aircraft.json when a
+db-file is loaded (the reg/dbFlags JSON block is gated on Modes.db).
+
+Fed via beast DF17 so the aircraft carry real ICAO addresses that match the db.
+"""
+
+import gzip
+import json
+import os
+import socket
+import tempfile
+import time
+import unittest
+
+from conftest import ReadsbInstance, beast_frame, make_df17_position, wait_for_port
+
+MIL_HEX = "abc123"      # in db, dbFlags bit0 = 1 (military)
+CIVIL_HEX = "def456"    # in db, dbFlags = 0
+RANGE_MIL_HEX = "3ea123"  # NOT in db; German military address range
+
+
+def make_db_gz():
+    """Write a gzipped tar1090-db-format CSV; return its path. Padded > 1000 bytes."""
+    rows = [
+        f"{MIL_HEX};N737AX;B738;1;Boeing 737-800;2015;TestAir;",
+        f"{CIVIL_HEX};G-CIVL;A320;0;Airbus A320;2018;CivilAir;",
+    ]
+    for i in range(40):
+        rows.append(f"{0x200000 + i:06x};N{i:05d};C172;0;Cessna 172 Skyhawk;2001;PadAir;")
+    csv = ("\n".join(rows) + "\n").encode()
+    fd, path = tempfile.mkstemp(suffix=".csv.gz")
+    os.close(fd)
+    with gzip.open(path, "wb") as f:
+        f.write(csv)
+    return path
+
+
+def feed_positions(beast_port, hexes, rounds=15):
+    sock = socket.create_connection(("127.0.0.1", beast_port), timeout=5)
+    for _ in range(rounds):
+        for hx in hexes:
+            sock.sendall(beast_frame(make_df17_position(hx, 51.5, -0.1, 35000, 0)))
+            sock.sendall(beast_frame(make_df17_position(hx, 51.5, -0.1, 35000, 1)))
+        time.sleep(0.3)
+    return sock
+
+
+def poll_for_enriched(json_dir, want_hex, timeout=10):
+    """Poll aircraft.json until *want_hex* appears carrying a registration."""
+    from pathlib import Path
+    path = Path(json_dir) / "aircraft.json"
+    deadline = time.monotonic() + timeout
+    last = None
+    while time.monotonic() < deadline:
+        if path.exists():
+            try:
+                data = json.loads(path.read_text())
+                last = data
+                ac = next((a for a in data["aircraft"] if a.get("hex") == want_hex), None)
+                if ac and "r" in ac:
+                    return data
+            except (json.JSONDecodeError, OSError, KeyError):
+                pass
+        time.sleep(0.3)
+    return last
+
+
+class TestDbEnrichment(unittest.TestCase):
+    """--db-file registration/type/dbFlags enrichment + military classification."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.db_path = make_db_gz()
+        cls.inst = ReadsbInstance(
+            beast_in=True, extra_args=["--db-file", cls.db_path, "--db-file-lt"])
+        cls.inst.__enter__()
+        wait_for_port(cls.inst.beast_in_port)
+        time.sleep(2.0)  # let the initial db load complete (sets Modes.db)
+        cls.feeder = feed_positions(
+            cls.inst.beast_in_port, [MIL_HEX, CIVIL_HEX, RANGE_MIL_HEX])
+        cls.data = poll_for_enriched(cls.inst.tmpdir, MIL_HEX, timeout=10)
+
+    @classmethod
+    def tearDownClass(cls):
+        try:
+            cls.feeder.close()
+        except Exception:
+            pass
+        cls.inst.__exit__(None, None, None)
+        os.unlink(cls.db_path)
+
+    def _ac(self, hx):
+        self.assertIsNotNone(self.data, "aircraft.json never appeared")
+        ac = next((a for a in self.data["aircraft"] if a.get("hex") == hx), None)
+        self.assertIsNotNone(ac, f"{hx} not in aircraft.json")
+        return ac
+
+    def test_d1_registration_and_type_enrichment(self):
+        """db-file populates registration (r) and type code (t)."""
+        ac = self._ac(MIL_HEX)
+        self.assertEqual(ac.get("r"), "N737AX")
+        self.assertEqual(ac.get("t"), "B738")
+
+    def test_d2_military_flag_from_db(self):
+        """dbFlags military bit (bit 0) is set for the military db entry."""
+        ac = self._ac(MIL_HEX)
+        self.assertIsInstance(ac.get("dbFlags"), int)
+        self.assertEqual(ac["dbFlags"] & 1, 1, "military bit not set from db")
+
+    def test_d3_civil_entry_not_military(self):
+        """A civil db entry is enriched but not flagged military."""
+        ac = self._ac(CIVIL_HEX)
+        self.assertEqual(ac.get("r"), "G-CIVL")
+        self.assertEqual(ac.get("t"), "A320")
+        self.assertEqual(ac.get("dbFlags", 0) & 1, 0, "civil aircraft flagged military")
+
+    def test_d4_hardcoded_military_range(self):
+        """An address in a known military range is flagged even with no db entry."""
+        ac = self._ac(RANGE_MIL_HEX)
+        self.assertEqual(ac.get("dbFlags", 0) & 1, 1,
+                         "hardcoded military-range address not flagged military")
+
+    def test_d5_long_type_description(self):
+        """--db-file-lt adds the long type description (desc)."""
+        ac = self._ac(MIL_HEX)
+        self.assertEqual(ac.get("desc"), "Boeing 737-800")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/test_globe_history.py
+++ b/tests/test_globe_history.py
@@ -1,0 +1,87 @@
+"""
+Globe-history output integration test (--write-globe-history).
+
+readsb archives history under <history-dir>/YYYY/MM/DD/{traces/<last2hex>/, acas/}
+plus an internal_state/ blob set. The historical-export pipeline
+(push-scripts → customer buckets) walks this dated layout, so the directory
+structure is the contract pinned here against the 3.14.1631 baseline.
+
+Heatmap note: heatmap.bin generation (--heatmap) is gated on a day rollover /
+long runtime and is not reproducible in a short test — readsb only creates the
+dated heatmap/ directory in-window. So this test asserts the globe-history dir
+layout (incl. the heatmap dir when present), not the heatmap.bin blob itself.
+"""
+
+import shutil
+import tempfile
+import time
+import unittest
+from pathlib import Path
+
+from conftest import ReadsbInstance, feed_sbs, sbs_msg3, poll_aircraft_json
+
+# YYYY/MM/DD glob (date-agnostic)
+DATED_GLOB = "[0-9][0-9][0-9][0-9]/[0-9][0-9]/[0-9][0-9]"
+
+
+def poll_history_layout(hist_dir, timeout=20):
+    """Poll until a dated YYYY/MM/DD dir with a traces/ subdir appears."""
+    hist = Path(hist_dir)
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        dated = [p for p in hist.glob(DATED_GLOB)
+                 if p.is_dir() and (p / "traces").is_dir()]
+        if dated:
+            return sorted(dated)
+        time.sleep(0.5)
+    return sorted(p for p in hist.glob(DATED_GLOB) if p.is_dir())
+
+
+class TestGlobeHistory(unittest.TestCase):
+    """globe-history dated directory layout."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.histdir = tempfile.mkdtemp(prefix="readsb-hist-")
+        cls.inst = ReadsbInstance(extra_args=[
+            "--write-json-globe-index",
+            "--write-globe-history", cls.histdir,
+            "--json-trace-interval", "1",
+        ])
+        cls.inst.__enter__()
+        sock = cls.inst.feeder()
+        for _ in range(24):
+            feed_sbs(sock, [sbs_msg3("ABC123", alt=35000, lat=51.5, lon=-0.1)])
+            time.sleep(0.5)
+        poll_aircraft_json(cls.inst.tmpdir, timeout=8, want_hex="abc123")
+        cls.dated = poll_history_layout(cls.histdir, timeout=20)
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.inst.__exit__(None, None, None)
+        shutil.rmtree(cls.histdir, ignore_errors=True)
+
+    def test_h1_dated_directory_created(self):
+        """A YYYY/MM/DD dated directory is created under the history dir."""
+        self.assertTrue(self.dated,
+                        "no YYYY/MM/DD dated directory under the history dir")
+
+    def test_h2_dated_dir_has_traces_and_acas(self):
+        """Each dated dir contains the traces/ and acas/ subdirs exporters expect."""
+        self.assertTrue(self.dated, "no dated dir to inspect")
+        day = self.dated[-1]
+        self.assertTrue((day / "traces").is_dir(),
+                        f"missing traces/ under {day}")
+        self.assertTrue((day / "acas").is_dir(),
+                        f"missing acas/ under {day}")
+
+    def test_h3_internal_state_blobs(self):
+        """internal_state/ blob set is written (state persistence for restarts)."""
+        state = Path(self.histdir) / "internal_state"
+        self.assertTrue(state.is_dir(), "internal_state/ dir not written")
+        blobs = list(state.glob("blob_*"))
+        self.assertGreater(len(blobs), 0, "no internal_state blobs written")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/test_globe_index.py
+++ b/tests/test_globe_index.py
@@ -1,0 +1,148 @@
+"""
+Globe-index output integration tests (--write-json-globe-index).
+
+This is the tar1090 globe-view contract: with --write-json-globe-index, readsb
+shards positioned aircraft into globe_<index>.json tiles by location and
+advertises the grid + special tiles in receiver.json. Tiles are gzip-compressed
+JSON (served by tar1090 with Content-Encoding: gzip) despite the .json suffix.
+
+G1-G4: output present + correct with the flag.
+G5-G6: negative control — no globe output without the flag.
+"""
+
+import gzip
+import json
+import time
+import unittest
+from pathlib import Path
+
+from conftest import ReadsbInstance, feed_sbs, sbs_msg3, poll_aircraft_json
+
+
+TILE_BBOX_KEYS = {"north", "south", "east", "west"}
+
+
+def read_tile(path):
+    """Read a globe_*.json tile (gzip-compressed despite the .json extension)."""
+    raw = Path(path).read_bytes()
+    if raw[:2] == b"\x1f\x8b":
+        raw = gzip.decompress(raw)
+    return json.loads(raw)
+
+
+def globe_json_tiles(json_dir):
+    """All globe_<index>.json tile paths in *json_dir* (excludes binCraft/Mil)."""
+    return sorted(
+        p for p in Path(json_dir).iterdir()
+        if p.name.startswith("globe_") and p.name.endswith(".json")
+    )
+
+
+def poll_globe_tile_for_hex(json_dir, want_hex, timeout=10):
+    """Poll globe tiles until *want_hex* appears; return the containing tile dict."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        for p in globe_json_tiles(json_dir):
+            try:
+                tile = read_tile(p)
+            except (OSError, ValueError):
+                continue
+            if any(a.get("hex") == want_hex for a in tile.get("aircraft", [])):
+                return tile
+        time.sleep(0.3)
+    return None
+
+
+class TestGlobeIndex(unittest.TestCase):
+    """globe_*.json tiles + receiver.json globe-index fields with the flag set."""
+
+    HEX = "abc123"
+    LAT = 51.5
+    LON = -0.1
+
+    @classmethod
+    def setUpClass(cls):
+        cls.inst = ReadsbInstance(extra_args=["--write-json-globe-index"])
+        cls.inst.__enter__()
+        sock = cls.inst.feeder()
+        # Feed repeatedly so the position stays fresh across a tile-write cycle.
+        for _ in range(12):
+            feed_sbs(sock, [sbs_msg3(cls.HEX, alt=35000, lat=cls.LAT, lon=cls.LON)])
+            time.sleep(0.2)
+        # Confirm the aircraft is established with a position before asserting.
+        poll_aircraft_json(cls.inst.tmpdir, timeout=8, want_hex=cls.HEX)
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.inst.__exit__(None, None, None)
+
+    def test_g1_globe_tiles_written(self):
+        """globe_*.json tiles are written when --write-json-globe-index is set."""
+        tiles = globe_json_tiles(self.inst.tmpdir)
+        self.assertGreater(len(tiles), 0, "no globe_*.json tiles written")
+
+    def test_g2_tile_is_gzipped_json_with_schema(self):
+        """A globe tile is gzip-compressed JSON with the expected tile schema."""
+        tiles = globe_json_tiles(self.inst.tmpdir)
+        self.assertTrue(tiles, "no globe tiles to inspect")
+        self.assertEqual(tiles[0].read_bytes()[:2], b"\x1f\x8b",
+                         "globe tile should be gzip-compressed")
+        tile = read_tile(tiles[0])
+        for key in ("aircraft", "globeIndex", "now", "messages",
+                    "north", "south", "east", "west"):
+            self.assertIn(key, tile, f"globe tile missing '{key}'")
+        self.assertIsInstance(tile["aircraft"], list)
+
+    def test_g3_receiver_advertises_globe_index(self):
+        """receiver.json exposes globeIndexGrid + globeIndexSpecialTiles."""
+        rec = json.loads((Path(self.inst.tmpdir) / "receiver.json").read_text())
+        self.assertIn("globeIndexGrid", rec)
+        self.assertIsInstance(rec["globeIndexGrid"], int)
+        self.assertIn("globeIndexSpecialTiles", rec)
+        special = rec["globeIndexSpecialTiles"]
+        self.assertIsInstance(special, list)
+        self.assertGreater(len(special), 0, "globeIndexSpecialTiles is empty")
+        self.assertTrue(TILE_BBOX_KEYS.issubset(special[0].keys()),
+                        f"special tile missing bbox keys: {special[0]}")
+
+    def test_g4_aircraft_lands_in_covering_tile(self):
+        """A positioned aircraft appears in the globe tile whose bbox contains it."""
+        tile = poll_globe_tile_for_hex(self.inst.tmpdir, self.HEX, timeout=10)
+        self.assertIsNotNone(tile, f"{self.HEX} not found in any globe tile")
+        self.assertLessEqual(tile["south"], self.LAT, "tile south edge above aircraft")
+        self.assertGreaterEqual(tile["north"], self.LAT, "tile north edge below aircraft")
+        self.assertLessEqual(tile["west"], self.LON, "tile west edge east of aircraft")
+        self.assertGreaterEqual(tile["east"], self.LON, "tile east edge west of aircraft")
+
+
+class TestGlobeIndexDisabled(unittest.TestCase):
+    """Negative control: without the flag, no globe output at all."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.inst = ReadsbInstance()  # no --write-json-globe-index
+        cls.inst.__enter__()
+        sock = cls.inst.feeder()
+        for _ in range(4):
+            feed_sbs(sock, [sbs_msg3("DEF456", alt=30000, lat=48.0, lon=2.3)])
+            time.sleep(0.2)
+        time.sleep(1.5)
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.inst.__exit__(None, None, None)
+
+    def test_g5_no_globe_tiles_without_flag(self):
+        """No globe_*.json tiles are written without --write-json-globe-index."""
+        tiles = globe_json_tiles(self.inst.tmpdir)
+        self.assertEqual(tiles, [],
+                         f"unexpected globe tiles: {[p.name for p in tiles]}")
+
+    def test_g6_no_globe_index_fields_without_flag(self):
+        """receiver.json omits globeIndexGrid without the flag."""
+        rec = json.loads((Path(self.inst.tmpdir) / "receiver.json").read_text())
+        self.assertNotIn("globeIndexGrid", rec)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/test_json_out_stream.py
+++ b/tests/test_json_out_stream.py
@@ -1,0 +1,93 @@
+"""
+json_out streaming record integration test (--net-json-port).
+
+The EKS data-ingestion readsb runs --net-only and forwards json_out over TCP to
+Vector, which feeds the MSK streaming pipeline. --net-json-port "sends one line
+with a json object containing aircraft details for every position received".
+This pins the streaming record schema so a field change is caught before it
+reaches the pipeline. Driven with beast input (the real apex -> streaming path).
+"""
+
+import json
+import socket
+import time
+import unittest
+
+from conftest import (
+    ReadsbInstance, beast_frame, make_df17_position, wait_for_port,
+)
+
+
+def read_json_line(sock, timeout=10):
+    """Read one newline-terminated JSON object from a json_out connection."""
+    sock.settimeout(timeout)
+    buf = b""
+    try:
+        while b"\n" not in buf:
+            chunk = sock.recv(4096)
+            if not chunk:
+                break
+            buf += chunk
+    except socket.timeout:
+        pass
+    line = buf.split(b"\n")[0].strip()
+    return json.loads(line) if line else None
+
+
+class TestJsonOutStream(unittest.TestCase):
+    """One JSON object per position on the --net-json-port stream."""
+
+    HEX = "abc123"
+    LAT = 51.5
+    LON = -0.1
+    ALT = 35000
+
+    @classmethod
+    def setUpClass(cls):
+        cls.inst = ReadsbInstance(beast_in=True, json_out=True)
+        cls.inst.__enter__()
+        wait_for_port(cls.inst.beast_in_port)
+        cls.client = socket.create_connection(
+            ("127.0.0.1", cls.inst.json_out_port), timeout=5)
+        feeder = socket.create_connection(
+            ("127.0.0.1", cls.inst.beast_in_port), timeout=5)
+        # Even/odd CPR pairs so a position resolves and json_out emits.
+        for _ in range(15):
+            feeder.sendall(beast_frame(make_df17_position(cls.HEX, cls.LAT, cls.LON, cls.ALT, 0)))
+            feeder.sendall(beast_frame(make_df17_position(cls.HEX, cls.LAT, cls.LON, cls.ALT, 1)))
+            time.sleep(0.3)
+        cls.record = read_json_line(cls.client, timeout=10)
+        feeder.close()
+
+    @classmethod
+    def tearDownClass(cls):
+        try:
+            cls.client.close()
+        except Exception:
+            pass
+        cls.inst.__exit__(None, None, None)
+
+    def test_j1_emits_json_object_per_position(self):
+        """The stream emits a newline-terminated JSON object for a position."""
+        self.assertIsNotNone(self.record, "no json_out record received")
+        self.assertIsInstance(self.record, dict)
+
+    def test_j2_record_identifies_aircraft_and_position(self):
+        """The record carries hex + the decoded position the pipeline consumes."""
+        self.assertEqual(self.record.get("hex"), self.HEX)
+        self.assertIsInstance(self.record.get("lat"), (int, float))
+        self.assertIsInstance(self.record.get("lon"), (int, float))
+        # CPR-decoded; within a fraction of a degree of what we encoded
+        self.assertAlmostEqual(self.record["lat"], self.LAT, places=1)
+        self.assertAlmostEqual(self.record["lon"], self.LON, places=1)
+        self.assertEqual(self.record.get("alt_baro"), self.ALT)
+
+    def test_j3_record_has_streaming_fields(self):
+        """Record carries the fields the MSK pipeline relies on."""
+        for key in ("now", "seen", "seen_pos", "messages", "type"):
+            self.assertIn(key, self.record, f"json_out record missing '{key}'")
+        self.assertIsInstance(self.record["now"], (int, float))
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/test_output_files_extra.py
+++ b/tests/test_output_files_extra.py
@@ -1,0 +1,97 @@
+"""
+Extra output-file integration tests: --write-json-gzip and --write-prom.
+
+Both are used by the production readsb roles (adsbexchange-app configs):
+  * --write-json-gzip  -> aircraft.json.gz (tar1090 serves the gzipped variant)
+  * --write-prom       -> a Prometheus text-format metrics file scraped by
+                          node_exporter (every role writes one; the monitoring
+                          contract). Written on the stats cycle (~10s after
+                          start), so setUpClass waits for it.
+"""
+
+import gzip
+import json
+import os
+import tempfile
+import time
+import unittest
+from pathlib import Path
+
+from conftest import ReadsbInstance, feed_sbs, sbs_msg3, poll_aircraft_json
+
+
+def poll_file_nonempty(path, timeout=16):
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        try:
+            if os.path.getsize(path) > 0:
+                return Path(path).read_text()
+        except OSError:
+            pass
+        time.sleep(0.5)
+    return ""
+
+
+class TestExtraOutputFiles(unittest.TestCase):
+    """aircraft.json.gz + the Prometheus metrics file."""
+
+    @classmethod
+    def setUpClass(cls):
+        fd, cls.prom_path = tempfile.mkstemp(suffix=".prom")
+        os.close(fd)
+        cls.inst = ReadsbInstance(
+            extra_args=["--write-json-gzip", "--write-prom", cls.prom_path])
+        cls.inst.__enter__()
+        sock = cls.inst.feeder()
+        for _ in range(6):
+            feed_sbs(sock, [sbs_msg3("ABC123", alt=35000, lat=51.5, lon=-0.1)])
+            time.sleep(0.3)
+        poll_aircraft_json(cls.inst.tmpdir, timeout=8, want_hex="abc123")
+        cls.prom_text = poll_file_nonempty(cls.prom_path, timeout=16)
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.inst.__exit__(None, None, None)
+        os.unlink(cls.prom_path)
+
+    # ---- --write-json-gzip ----
+
+    def test_e1_aircraft_json_gz_written_and_valid(self):
+        """aircraft.json.gz is written, gzip-compressed, and parses."""
+        gz = Path(self.inst.tmpdir) / "aircraft.json.gz"
+        self.assertTrue(gz.exists(), "aircraft.json.gz not written")
+        self.assertEqual(gz.read_bytes()[:2], b"\x1f\x8b", "not gzip-compressed")
+        data = json.loads(gzip.decompress(gz.read_bytes()))
+        self.assertIn("aircraft", data)
+        self.assertIn("now", data)
+
+    def test_e2_gz_matches_plain_json(self):
+        """aircraft.json.gz carries the same aircraft set as aircraft.json."""
+        d = Path(self.inst.tmpdir)
+        plain = json.loads((d / "aircraft.json").read_text())
+        gzd = json.loads(gzip.decompress((d / "aircraft.json.gz").read_bytes()))
+        self.assertEqual({a["hex"] for a in gzd["aircraft"]},
+                         {a["hex"] for a in plain["aircraft"]})
+
+    # ---- --write-prom ----
+
+    def test_e3_prom_file_has_readsb_metrics(self):
+        """The Prometheus file is written with readsb_ metrics."""
+        self.assertTrue(self.prom_text, "prom file never populated")
+        readsb_metrics = [l for l in self.prom_text.splitlines()
+                          if l.startswith("readsb_")]
+        self.assertGreater(len(readsb_metrics), 0, "no readsb_ metrics in prom file")
+
+    def test_e4_prom_lines_are_valid_format(self):
+        """Each metric line is `name[{labels}] <numeric value>` (node_exporter-parseable)."""
+        sample = [l for l in self.prom_text.splitlines()
+                  if l and not l.startswith("#")][:20]
+        self.assertTrue(sample, "no metric lines")
+        for line in sample:
+            parts = line.rsplit(" ", 1)
+            self.assertEqual(len(parts), 2, f"unparseable metric line: {line!r}")
+            float(parts[1])  # value must be numeric; raises on failure
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/test_receiver_json.py
+++ b/tests/test_receiver_json.py
@@ -1,0 +1,73 @@
+"""
+receiver.json capability-field integration test.
+
+receiver.json advertises the capabilities tar1090 branches on (binary/zstd
+output, trace interval, the globe-index grid + special tiles). This pins the
+full field set + types 3.14.1631 emits with --write-json-globe-index, so the
+reconciliation walk flags any change at the commit that introduces it.
+
+Note: `haveTraces` is NOT emitted by 3.14.1631 (even with traces written), so it
+is intentionally not asserted here — if a later upstream version adds it, that is
+a new field to evaluate, not a regression.
+"""
+
+import json
+import time
+import unittest
+from pathlib import Path
+
+from conftest import ReadsbInstance, feed_sbs, sbs_msg3
+
+TILE_BBOX_KEYS = {"north", "south", "east", "west"}
+
+
+class TestReceiverJsonFields(unittest.TestCase):
+    """Full receiver.json capability contract (globe-index config)."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.inst = ReadsbInstance(extra_args=["--write-json-globe-index"])
+        cls.inst.__enter__()
+        sock = cls.inst.feeder()
+        for _ in range(4):
+            feed_sbs(sock, [sbs_msg3("ABC123", alt=35000, lat=51.5, lon=-0.1)])
+            time.sleep(0.2)
+        time.sleep(1.5)
+        cls.rec = json.loads((Path(cls.inst.tmpdir) / "receiver.json").read_text())
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.inst.__exit__(None, None, None)
+
+    def test_r1_core_fields(self):
+        """version / refresh / history present and typed."""
+        self.assertIsInstance(self.rec.get("version"), str)
+        self.assertTrue(self.rec["version"], "version is empty")
+        # version string starts with the numeric version (not asserting the
+        # build-identity label, which is reverted during the reconciliation walk)
+        self.assertTrue(self.rec["version"][0].isdigit(),
+                        f"version should start with a version number: {self.rec['version']!r}")
+        self.assertIsInstance(self.rec.get("refresh"), (int, float))
+        self.assertGreater(self.rec["refresh"], 0)
+        self.assertIn("history", self.rec)
+
+    def test_r2_output_capability_flags(self):
+        """binCraft / zstd / json_trace_interval capability flags."""
+        self.assertIsInstance(self.rec.get("binCraft"), bool)
+        self.assertIsInstance(self.rec.get("zstd"), bool)
+        self.assertIsInstance(self.rec.get("json_trace_interval"), (int, float))
+        self.assertGreater(self.rec["json_trace_interval"], 0)
+
+    def test_r3_globe_index_capability(self):
+        """globeIndexGrid + globeIndexSpecialTiles (the tar1090 globe contract)."""
+        self.assertIsInstance(self.rec.get("globeIndexGrid"), int)
+        self.assertGreater(self.rec["globeIndexGrid"], 0)
+        special = self.rec.get("globeIndexSpecialTiles")
+        self.assertIsInstance(special, list)
+        self.assertGreater(len(special), 0)
+        self.assertTrue(TILE_BBOX_KEYS.issubset(special[0].keys()),
+                        f"special tile missing bbox keys: {special[0]}")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/test_state_persistence.py
+++ b/tests/test_state_persistence.py
@@ -1,0 +1,121 @@
+"""
+State persistence round-trip integration test (--write-state).
+
+The globe / re-api roles use --write-state so aircraft + traces survive a
+restart. The 2024 upgrade's top operational risk was "state drift / corrupted
+hexes" on re-api after upgrading. This test exercises the round-trip directly:
+feed an aircraft, write state on exit, restart pointed at the same state dir,
+and assert the aircraft (and its position) is restored without any new feed.
+
+Two-phase, so it drives readsb subprocesses directly rather than using the
+single-process ReadsbInstance harness.
+"""
+
+import shutil
+import socket
+import subprocess
+import tempfile
+import time
+import unittest
+from pathlib import Path
+
+from conftest import (
+    READSB_BIN, get_free_port, wait_for_port, feed_sbs, sbs_msg3,
+    poll_aircraft_json,
+)
+
+HEX = "abc123"
+LAT = 51.5
+LON = -0.1
+ALT = 35000
+
+
+def start_readsb(json_dir, state_dir, only_on_exit):
+    """Start a readsb subprocess writing state to *state_dir*; return (proc, sbs_port)."""
+    sbs_port = get_free_port()
+    api_port = get_free_port()
+    cmd = [
+        str(READSB_BIN), "--net-only", "--quiet",
+        "--write-json", json_dir,
+        "--write-state", state_dir,
+        "--net-sbs-in-port", str(sbs_port),
+        "--net-api-port", str(api_port),
+        "--auto-exit", "120",
+    ]
+    if only_on_exit:
+        cmd.append("--write-state-only-on-exit")
+    proc = subprocess.Popen(cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+    if not wait_for_port(sbs_port):
+        proc.kill(); proc.wait()
+        raise RuntimeError("readsb failed to start")
+    return proc, sbs_port
+
+
+def stop(proc):
+    """SIGTERM readsb (triggers the on-exit state write) and wait for it to flush."""
+    if proc.poll() is None:
+        proc.terminate()
+        try:
+            proc.wait(timeout=10)
+        except subprocess.TimeoutExpired:
+            proc.kill(); proc.wait()
+
+
+class TestStatePersistence(unittest.TestCase):
+    """write-state -> restart -> aircraft + position restored."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.state_dir = tempfile.mkdtemp(prefix="readsb-state-")
+        cls.json1 = tempfile.mkdtemp(prefix="readsb-json1-")
+        cls.json2 = tempfile.mkdtemp(prefix="readsb-json2-")
+
+        # Phase 1: feed an aircraft with a position, then exit (writes state).
+        p1, sbs_port = start_readsb(cls.json1, cls.state_dir, only_on_exit=True)
+        sock = socket.create_connection(("127.0.0.1", sbs_port), timeout=5)
+        for _ in range(12):
+            feed_sbs(sock, [sbs_msg3(HEX, alt=ALT, lat=LAT, lon=LON)])
+            time.sleep(0.3)
+        cls.before = poll_aircraft_json(cls.json1, timeout=8, want_hex=HEX)
+        sock.close()
+        stop(p1)
+        time.sleep(1.0)  # let the on-exit state write settle
+        cls.state_files = [p.name for p in Path(cls.state_dir).rglob("*") if p.is_file()]
+
+        # Phase 2: restart from the same state dir with NO feed.
+        cls.p2, _ = start_readsb(cls.json2, cls.state_dir, only_on_exit=False)
+        cls.after = poll_aircraft_json(cls.json2, timeout=10, want_hex=HEX)
+
+    @classmethod
+    def tearDownClass(cls):
+        stop(cls.p2)
+        for d in (cls.state_dir, cls.json1, cls.json2):
+            shutil.rmtree(d, ignore_errors=True)
+
+    def test_s1_state_written_on_exit(self):
+        """State blobs are written to the state dir on exit."""
+        blobs = [f for f in self.state_files if f.startswith("blob_")]
+        self.assertGreater(len(blobs), 0,
+                           f"no state blobs written; got {self.state_files}")
+
+    def test_s2_aircraft_restored_after_restart(self):
+        """The fed aircraft reappears after restart with no new feed."""
+        self.assertIsNotNone(self.before, "aircraft was not present before restart")
+        self.assertIsNotNone(self.after,
+                             "aircraft.json never repopulated after restart")
+        hexes = {a.get("hex") for a in self.after["aircraft"]}
+        self.assertIn(HEX, hexes,
+                      "aircraft not restored from state after restart")
+
+    def test_s3_restored_position_intact(self):
+        """Restored aircraft keeps its position (guards against state drift)."""
+        self.assertIsNotNone(self.after)
+        ac = next((a for a in self.after["aircraft"] if a.get("hex") == HEX), None)
+        self.assertIsNotNone(ac, f"{HEX} not restored")
+        self.assertIn("lat", ac, "restored aircraft lost its position")
+        self.assertAlmostEqual(ac["lat"], LAT, places=2)
+        self.assertAlmostEqual(ac["lon"], LON, places=2)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/test_trace_files.py
+++ b/tests/test_trace_files.py
@@ -1,0 +1,133 @@
+"""
+Trace-file format integration tests (--write-json-globe-index traces).
+
+readsb writes per-aircraft history traces to <json-dir>/traces/<last2hex>/
+as trace_recent_<icao>.json and trace_full_<icao>.json (gzip-compressed
+despite the .json suffix). Each file is {icao, timestamp, trace[]} where every
+trace point is a fixed-length array:
+
+  [0] time offset from `timestamp` (s)   [7] vertical rate
+  [1] latitude                           [8] per-point detail object {type,...}
+  [2] longitude                          [9] type string
+  [3] baro altitude                      [10] geom altitude
+  [4] ground speed                       [11] geom rate
+  [5] track                              [12] ias
+  [6] flags bitfield                     [13] roll
+
+This is the contract tar1090 trace replay and push-scripts/export-traces parse;
+pinning the point-array length catches any upstream layout change at the exact
+commit that introduces it.
+"""
+
+import gzip
+import json
+import time
+import unittest
+from pathlib import Path
+
+from conftest import ReadsbInstance, feed_sbs, sbs_msg3, poll_aircraft_json
+
+# Observed trace-point array length for readsb 3.14.1631 (the reconciliation
+# baseline). A change here breaks downstream trace parsers — treat as a gate.
+TRACE_POINT_LEN = 14
+
+
+def read_trace(path):
+    """Read a trace_*.json file (gzip-compressed despite the .json extension)."""
+    raw = Path(path).read_bytes()
+    if raw[:2] == b"\x1f\x8b":
+        raw = gzip.decompress(raw)
+    return json.loads(raw)
+
+
+def find_trace_files(json_dir, icao):
+    """Return (recent_path, full_path) for *icao*, or (None, None) if absent."""
+    traces = Path(json_dir) / "traces"
+    recent = next(traces.rglob(f"trace_recent_{icao}.json"), None) if traces.exists() else None
+    full = next(traces.rglob(f"trace_full_{icao}.json"), None) if traces.exists() else None
+    return recent, full
+
+
+def poll_trace_files(json_dir, icao, timeout=20):
+    """Poll until both trace files exist and parse with >=1 point."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        recent, full = find_trace_files(json_dir, icao)
+        if recent and full:
+            try:
+                if read_trace(recent).get("trace") and read_trace(full).get("trace"):
+                    return recent, full
+            except (OSError, ValueError):
+                pass
+        time.sleep(0.5)
+    return find_trace_files(json_dir, icao)
+
+
+class TestTraceFiles(unittest.TestCase):
+    """trace_recent / trace_full files + point-array contract."""
+
+    HEX = "abc123"
+    LAT = 51.5
+    LON = -0.1
+    ALT = 35000
+
+    @classmethod
+    def setUpClass(cls):
+        cls.inst = ReadsbInstance(
+            extra_args=["--write-json-globe-index", "--json-trace-interval", "1"],
+        )
+        cls.inst.__enter__()
+        sock = cls.inst.feeder()
+        # Static position (accepted by the speed-plausibility gate); a trace point
+        # is recorded ~every --json-trace-interval, so points accumulate over time.
+        for _ in range(24):
+            feed_sbs(sock, [sbs_msg3(cls.HEX, alt=cls.ALT, lat=cls.LAT, lon=cls.LON,
+                                     gs=450, track=90)])
+            time.sleep(0.5)
+        poll_aircraft_json(cls.inst.tmpdir, timeout=8, want_hex=cls.HEX)
+        cls.recent, cls.full = poll_trace_files(cls.inst.tmpdir, cls.HEX, timeout=20)
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.inst.__exit__(None, None, None)
+
+    def test_t1_trace_files_written(self):
+        """trace_recent and trace_full files are written under traces/<last2hex>/."""
+        self.assertIsNotNone(self.recent, "trace_recent file not written")
+        self.assertIsNotNone(self.full, "trace_full file not written")
+        # sharded by the last byte of the ICAO hex
+        self.assertEqual(self.recent.parent.name, self.HEX[-2:])
+
+    def test_t2_trace_files_gzipped(self):
+        """Trace files are gzip-compressed (tar1090 serves them so)."""
+        self.assertEqual(self.recent.read_bytes()[:2], b"\x1f\x8b")
+        self.assertEqual(self.full.read_bytes()[:2], b"\x1f\x8b")
+
+    def test_t3_trace_root_structure(self):
+        """Trace root is {icao, timestamp, trace[]} with our aircraft + a base time."""
+        data = read_trace(self.full)
+        self.assertEqual(data.get("icao"), self.HEX)
+        self.assertIn("timestamp", data)
+        self.assertIsInstance(data["timestamp"], (int, float))
+        self.assertGreater(data["timestamp"], 1577836800)  # after 2020
+        self.assertIsInstance(data.get("trace"), list)
+        self.assertGreater(len(data["trace"]), 0, "trace has no points")
+
+    def test_t4_trace_point_array_contract(self):
+        """Each trace point is the fixed-length array; pos fields match what we fed."""
+        data = read_trace(self.recent)
+        point = data["trace"][0]
+        self.assertIsInstance(point, list)
+        self.assertEqual(len(point), TRACE_POINT_LEN,
+                         f"trace point array length changed (downstream parsers "
+                         f"depend on it): got {len(point)}, expected {TRACE_POINT_LEN}")
+        self.assertIsInstance(point[0], (int, float))          # [0] time offset
+        self.assertAlmostEqual(point[1], self.LAT, places=2)   # [1] latitude
+        self.assertAlmostEqual(point[2], self.LON, places=2)   # [2] longitude
+        self.assertEqual(point[3], self.ALT)                   # [3] baro altitude
+        self.assertIsInstance(point[8], dict)                  # [8] per-point detail
+        self.assertIsInstance(point[9], str)                   # [9] type string
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/test_trace_hist_only.py
+++ b/tests/test_trace_hist_only.py
@@ -1,0 +1,58 @@
+"""
+Trace hist-only mode integration test (--json-trace-hist-only 3).
+
+The hrtraces and globe-history roles run with --json-trace-hist-only 3, which
+means "don't write recent(1) or full(2) traces to /run — archive to
+write-globe-history only". This is the opposite of the default (test_trace_files
+covers traces being written to /run). Here we pin that the flag suppresses the
+/run trace files while the aircraft is still tracked normally.
+"""
+
+import time
+import unittest
+from pathlib import Path
+
+from conftest import ReadsbInstance, feed_sbs, sbs_msg3, poll_aircraft_json
+
+
+class TestTraceHistOnly(unittest.TestCase):
+    """--json-trace-hist-only 3 suppresses /run trace files."""
+
+    HEX = "abc123"
+
+    @classmethod
+    def setUpClass(cls):
+        cls.inst = ReadsbInstance(extra_args=[
+            "--write-json-globe-index",
+            "--json-trace-interval", "1",
+            "--json-trace-hist-only", "3",
+        ])
+        cls.inst.__enter__()
+        sock = cls.inst.feeder()
+        for _ in range(20):
+            feed_sbs(sock, [sbs_msg3(cls.HEX, alt=35000, lat=51.5, lon=-0.1)])
+            time.sleep(0.3)
+        cls.data = poll_aircraft_json(cls.inst.tmpdir, timeout=8, want_hex=cls.HEX)
+        time.sleep(2)  # give any (suppressed) trace writes a chance to appear
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.inst.__exit__(None, None, None)
+
+    def test_t1_no_run_trace_files(self):
+        """With hist-only 3, no trace_recent/full files are written under /run."""
+        traces = Path(self.inst.tmpdir) / "traces"
+        run_traces = list(traces.rglob("trace_*.json")) if traces.exists() else []
+        self.assertEqual(run_traces, [],
+                         f"hist-only 3 should suppress /run traces; got {[p.name for p in run_traces]}")
+
+    def test_t2_aircraft_still_tracked(self):
+        """The aircraft is still tracked/positioned (the feed path is unaffected)."""
+        self.assertIsNotNone(self.data, "aircraft.json never appeared")
+        ac = next((a for a in self.data["aircraft"] if a.get("hex") == self.HEX), None)
+        self.assertIsNotNone(ac, f"{self.HEX} not tracked")
+        self.assertIn("lat", ac, "aircraft has no position")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tools/upstream-sync/README.md
+++ b/tools/upstream-sync/README.md
@@ -1,0 +1,21 @@
+# upstream-sync
+
+Tooling to triage upstream `wiedehopf/readsb` commits when reconciling this fork.
+
+## Files
+
+- `classify.py` — walks `merge-base(master, upstream/dev)..upstream/dev` and writes a first-pass triage ledger, classifying each commit **take / adapt / skip** by the files it touches.
+- `refine.py` — resolves the rows `classify.py` leaves as `needs_unit_test='?'` (non-critical core code) and sets the `commit_strategy` column.
+- `commits-ledger.tsv` — the generated ledger. Columns: `sha · date · subject · files · decision · reason · needs_unit_test · needs_devenv · commit_strategy · coupled_to · status`.
+
+## Usage
+
+Requires the `upstream` remote (`git remote add upstream https://github.com/wiedehopf/readsb.git`). Run from anywhere inside the repo:
+
+```bash
+git fetch upstream
+python3 tools/upstream-sync/classify.py   # regenerates commits-ledger.tsv
+python3 tools/upstream-sync/refine.py      # resolves '?' rows + commit_strategy
+```
+
+Re-run both after each `git fetch upstream` to re-triage new commits. The output is deterministic (same range → same ledger).

--- a/tools/upstream-sync/classify.py
+++ b/tools/upstream-sync/classify.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+"""Pre-classify upstream readsb commits into a triage ledger (take/adapt/skip).
+
+Walks merge-base(master, upstream/dev)..upstream/dev and classifies each commit
+by the files it touches: core decode/output paths -> take (test-backed);
+debian/changelog & release tooling -> skip; ADSBx-customized build files ->
+adapt; etc. Output is a first-pass ledger (commits-ledger.tsv); run refine.py
+afterwards to resolve the needs_unit_test='?' rows and the commit_strategy.
+Re-run both after each `git fetch upstream` to re-triage new commits.
+
+Requires the `upstream` remote (https://github.com/wiedehopf/readsb.git).
+Run from anywhere inside the readsb repo/worktree.
+"""
+import subprocess, csv, re, os
+
+REPO = subprocess.run(["git", "rev-parse", "--show-toplevel"],
+                      capture_output=True, text=True, check=True).stdout.strip()
+LEDGER = os.path.join(os.path.dirname(os.path.abspath(__file__)), "commits-ledger.tsv")
+
+def git(*args):
+    return subprocess.run(["git", "-C", REPO, *args],
+                          capture_output=True, text=True, check=True).stdout
+
+mb = git("merge-base", "master", "upstream/dev").strip()
+rng = f"{mb}..upstream/dev"
+
+raw = git("log", "--reverse", "--no-merges",
+          "--pretty=format:@@@%H\t%cI\t%s", "--name-only", rng)
+
+# ---- parse into [(sha, date, subject, [files])] ----
+commits = []
+cur = None
+for line in raw.splitlines():
+    if line.startswith("@@@"):
+        if cur: commits.append(cur)
+        sha, date, subj = line[3:].split("\t", 2)
+        cur = (sha, date, subj, [])
+    elif line.strip() and cur:
+        cur[3].append(line.strip())
+if cur: commits.append(cur)
+
+# ---- file bucketing ----
+CRITICAL = ("mode_s", "track", "cpr", "net_io", "json_out", "globe_index",
+            "api", "aircraft", "comm_b", "icao_filter", "receiver", "demod")
+
+def bucket(f):
+    if f == "version": return "VERSION"
+    if f in ("tag.sh", "nogrind.sh", "changelog") or \
+       (f.endswith(".sh") and f not in ("buildToS3.sh", "checkapi.sh")): return "TOOLING"
+    if f == "debian/changelog": return "CHANGELOG"
+    if f.startswith("debian/"): return "PACKAGING"  # rules/control/service/manpages — ADSBx does NOT fork debian/
+    if f in ("Makefile", "Dockerfile", ".dockerignore", "required_packages") \
+       or f.startswith(".github/") or f.startswith("docker"): return "BUILD"
+    if f.endswith(".md") or f.startswith("README"): return "DOCS"
+    if re.search(r"(sdr_|rtlsdr|bladerf|hackrf|soapy|airspy|plutosdr|limesdr)", f): return "SDR"
+    if f.startswith(("compat/", "minilzo/", "uat2esnt/")): return "VENDORED"
+    if f.endswith("_tests.c") or f.startswith("tests/") or f == "unittests.c": return "TESTS"
+    if f.endswith((".c", ".h")): return "CORE"
+    return "OTHER"
+
+FOLLOWUP = re.compile(r"\b(fix|oops|typo|revert|actually|redo|hotfix|broke|"
+                      r"regression|undo|wrong|again|forgot|missing)\b", re.I)
+
+rows = []
+for sha, date, subj, files in commits:
+    bset = {bucket(f) for f in files}
+    nonver = bset - {"VERSION"}
+
+    decision = reason = ""
+    unit = dev = ""
+
+    if not nonver:
+        decision, reason = "skip", "version bump only"
+    elif nonver <= {"CHANGELOG"}:
+        decision, reason = "skip", "debian changelog metadata only"
+    elif "PACKAGING" in bset and "CORE" not in bset and re.search(r"sdr", subj, re.I):
+        decision, reason = "adapt", "debian SDR build profile may affect dpkg-buildpackage -Prtlsdr; verify"
+    elif nonver <= {"PACKAGING", "CHANGELOG"}:
+        decision, reason, unit = "take", "debian packaging (ADSBx does not fork debian/); keeps deb build current", "n"
+    elif nonver <= {"TOOLING", "DOCS", "CHANGELOG"}:
+        decision, reason = "skip", "upstream docs/release tooling; ADSBx uses own CI/README"
+    elif nonver <= {"VENDORED"}:
+        decision, reason, unit = "take", "vendored lib only", "n"
+    elif nonver <= {"BUILD", "CHANGELOG"}:
+        decision, reason = "adapt", "build/CI only; preserve ADSBx label+workflows"
+    elif nonver <= {"SDR", "PACKAGING", "CHANGELOG", "DOCS"}:
+        decision, reason, unit = "take", "SDR/hardware path; low test priority", "n"
+    elif nonver <= {"TESTS"}:
+        decision, reason, unit = "take", "upstream test change", "n"
+    elif "CORE" in bset:
+        crit = any(any(c in f for c in CRITICAL) for f in files)
+        decision = "take"
+        if crit:
+            reason, unit = "core decode/output path (critical)", "y"
+        else:
+            reason, unit = "core code (non-critical)", "?"
+        if "BUILD" in bset:   # only OUR customized build files need the tip-patch resolve; debian/ is not forked
+            decision = "adapt"
+            reason += " + touches build (resolve to ADSBx side)"
+    else:
+        decision, reason = "REVIEW", f"unclassified buckets: {sorted(nonver)}"
+
+    coupled = "follow-up?" if FOLLOWUP.search(subj) else ""
+
+    if len(files) <= 4:
+        fsum = ",".join(files)
+    else:
+        top = {}
+        for f in files:
+            k = f.split("/")[0] if "/" in f else f
+            top[k] = top.get(k, 0) + 1
+        fsum = f"{len(files)} files: " + ",".join(sorted(top))
+
+    rows.append({
+        "sha": sha[:9], "date": date[:10], "subject": subj[:80],
+        "files": fsum, "decision": decision, "reason": reason,
+        "needs_unit_test": unit, "needs_devenv": dev,
+        "commit_strategy": "", "coupled_to": coupled, "status": "",
+    })
+
+cols = ["sha","date","subject","files","decision","reason",
+        "needs_unit_test","needs_devenv","commit_strategy","coupled_to","status"]
+with open(LEDGER, "w", newline="") as fh:
+    w = csv.DictWriter(fh, fieldnames=cols, delimiter="\t")
+    w.writeheader(); w.writerows(rows)
+
+from collections import Counter
+dec = Counter(r["decision"] for r in rows)
+print(f"merge-base: {mb[:9]}  range: {rng}")
+print(f"total commits: {len(rows)}")
+for k in ("take","adapt","skip","REVIEW"):
+    print(f"  {k:7} {dec.get(k,0)}")
+print(f"ledger -> {LEDGER}")
+print("next: run refine.py to resolve needs_unit_test='?' rows")

--- a/tools/upstream-sync/commits-ledger.tsv
+++ b/tools/upstream-sync/commits-ledger.tsv
@@ -1,0 +1,475 @@
+sha	date	subject	files	decision	reason	needs_unit_test	needs_devenv	commit_strategy	coupled_to	status
+1d6ef5f5c	2024-06-11	invalidate CPRs when reaching position reliability zero	track.c	take	core decode/output path (critical)	y				
+c9b9020ee	2024-06-11	get going a bit quicker after reaching zero reliability	track.c	take	core decode/output path (critical)	y				
+dea46ed7b	2024-06-14	dockerfile use run mount	Dockerfile	take	build/CI only; preserve ADSBx label+workflows | retag->take: build hunks reconciled by tip customization patch			tip-patch		
+4f7a7f18c	2024-06-14	ifile: don't use synthetic time for stdin	demod_2400.c,sdr_ifile.c	take	core decode/output path (critical)	y				
+51f21881d	2024-06-18	cpr debug print	track.c	take	core decode/output path (critical)	y				
+526c5d7ff	2024-07-09	hackrf oddities	sdr_hackrf.c	take	SDR/hardware path; low test priority	n				
+874c84ea3	2024-07-10	non-MLAT aircraft without valid track data: more trace positions	globe_index.c	take	core decode/output path (critical)	y				
+1a4c123d2	2024-07-11	fix exit on hang logic not signaling exit properly	readsb.c	take	core code (non-critical) | exit-on-hang signaling; cover via test_lifecycle	y	y		follow-up?	
+1ed7c88c0	2024-07-11	incrementing version: 3.14.1632	debian/changelog,version	skip	debian changelog metadata only					
+00433443d	2024-07-11	--devel=forwardMinMessages,2	net_io.c,readsb.c,readsb.h	take	core decode/output path (critical)	y				
+8329053d9	2024-07-12	gpsd_in: ignore non-TPV messages	net_io.c	take	core decode/output path (critical)	y				
+94c4b2dec	2024-07-13	add --devel=tar1090NoGlobe	json_out.c,readsb.c,readsb.h	take	core decode/output path (critical)	y				
+07df2f253	2024-07-13	incrementing version: 3.14.1633	debian/changelog,version	skip	debian changelog metadata only					
+e04f85c7b	2024-07-13	Dockerfile: x86_64: compile with -march=nehalem	Dockerfile	take	build/CI only; preserve ADSBx label+workflows | retag->take: build hunks reconciled by tip customization patch			tip-patch		
+6ff799e19	2024-07-17	traces: don't save more ground positions than intended	globe_index.c	take	core decode/output path (critical)	y				
+62768aadb	2024-07-19	add geomag copyright notice	geomag.c	take	core code (non-critical) | cleanup/refactor; no behavior change	n				
+e62917e0d	2024-07-26	don't use the rpi zero reduction of cpu usage via preamble on non-arm platforms	readsb.c	take	core code (non-critical) | perf/memory; no observable output change	n				
+a3f82ffb1	2024-07-26	incrementing version: 3.14.1634	debian/changelog,version	skip	debian changelog metadata only					
+b6715be2e	2024-08-07	supress most errors for repeated connection failures	net_io.c,net_io.h	take	core decode/output path (critical)	y				
+f2a37b0a9	2024-08-07	net: better debug print	net_io.c	take	core decode/output path (critical)	y				
+62718821f	2024-08-07	incrementing version: 3.14.1635	debian/changelog,version	skip	debian changelog metadata only					
+d0b4e7193	2024-08-07	net-connector: improve error suppression	net_io.c	take	core decode/output path (critical)	y				
+a3a174cb8	2024-08-13	json output: fix when input is sbs input	net_io.c	take	core decode/output path (critical)	y			follow-up?	
+d2f12d9a2	2024-08-13	incrementing version: 3.14.1636	debian/changelog,version	skip	debian changelog metadata only					
+3da4c74de	2024-08-14	add --devel=legacy_history	readsb.c,readsb.h	take	core code (non-critical) | new --devel=legacy_history output mode	y				
+cae21dc28	2024-08-14	remove legacy history json files from readme	README-json.md	skip	upstream docs/release tooling; ADSBx uses own CI/README					
+e17499956	2024-08-18	update packages	Dockerfile,required_packages	take	build/CI only; preserve ADSBx label+workflows | retag->take: build hunks reconciled by tip customization patch			tip-patch		
+c4ba31b49	2024-08-18	docker: use separate repo for builder	.github/workflows/docker.yaml,Dockerfile	take	build/CI only; preserve ADSBx label+workflows | retag->take: build hunks reconciled by tip customization patch			tip-patch		
+24568a6f2	2024-08-18	incrementing version: 3.14.1637	debian/changelog,version	skip	debian changelog metadata only					
+7a651de8d	2024-08-18	docker: re-add tagged builds and build for sid	.github/workflows/docker.yaml	take	build/CI only; preserve ADSBx label+workflows | retag->take: build hunks reconciled by tip customization patch			tip-patch		
+31aa09e44	2024-08-18	docker: remove cache	.github/workflows/docker.yaml	take	build/CI only; preserve ADSBx label+workflows | retag->take: build hunks reconciled by tip customization patch			tip-patch		
+e7d8c49d3	2024-08-18	dockerfile yml	.github/workflows/docker.yaml	take	build/CI only; preserve ADSBx label+workflows | retag->take: build hunks reconciled by tip customization patch			tip-patch		
+bede96fa7	2024-08-20	readsb api: support accept-encoding: zstd	api.c,api.h	take	core decode/output path (critical)	y				
+bcf81a676	2024-08-20	capitalize response headers	api.c	take	core decode/output path (critical)	y				
+4065eb486	2024-08-21	fix: Ubuntu 24.04 package name change	debian/control	take	debian packaging (ADSBx does not fork debian/); keeps deb build current	n			follow-up?	
+66a04fe82	2024-08-22	make sure SBS positions out of receiver range are not used	track.c	take	core decode/output path (critical)	y				
+5da03b53f	2024-08-22	incrementing version: 3.14.1638	debian/changelog,version	skip	debian changelog metadata only					
+e8352b6ab	2024-08-22	deb building apparently needs fakeroot	README.md	skip	upstream docs/release tooling; ADSBx uses own CI/README					
+18ee0ef4d	2024-08-23	fixup required packages	required_packages	take	build/CI only; preserve ADSBx label+workflows | retag->take: build hunks reconciled by tip customization patch			tip-patch		
+61b77e1da	2024-08-24	don't call getaddrinfo quite as often	net_io.c,net_io.h	take	core decode/output path (critical)	y				
+6f9b0b82f	2024-08-25	add jaero exception to sbs range limit	track.c	take	core decode/output path (critical)	y				
+123fbf101	2024-08-25	incrementing version: 3.14.1639	debian/changelog,version	skip	debian changelog metadata only					
+d6932bb08	2024-09-02	make log_ppm work with argument 0 as expected	readsb.c	take	core code (non-critical) | debug/log output only	n				
+603523537	2024-09-15	copy full DB details to aircraft struct	aircraft.c,json_out.c,track.h	take	core decode/output path (critical)	y				
+78f140cc2	2024-09-16	couple of fixes to make ModeS beast work properly	5 files: net_io.c,net_io.h,readsb.c,readsb.h,sdr_beast.c	take	core decode/output path (critical)	y				
+4b1868567	2024-09-16	incrementing version: 3.14.1640	debian/changelog,version	skip	debian changelog metadata only					
+2ab35ba54	2024-09-17	cleanup df18 exception handling	aircraft.c,json_out.c,track.c,track.h	take	core decode/output path (critical)	y				
+85badfbcf	2024-09-17	streamline zlib gzbuffer things	globe_index.c,json_out.c,util.c,util.h	take	core decode/output path (critical)	y				
+85cab05e4	2024-09-17	prepare aircraft db change / cleanup	aircraft.c	take	core decode/output path (critical)	y				
+ae09ee115	2024-09-17	readwholeGz minor cleanup	util.c	take	core code (non-critical) | cleanup/refactor; no behavior change	n				
+7086b20e8	2024-09-17	change aircraft db to use less memory	aircraft.c,aircraft.h,readsb.h	take	core decode/output path (critical)	y				
+85b918727	2024-09-17	incrementing version: 3.14.1641	debian/changelog,version	skip	debian changelog metadata only					
+6ee23d772	2024-09-28	fixup uptime in stats	readsb.c,readsb.h,stats.c,util.c	take	core code (non-critical) | uptime in stats output; test_stats_and_history	y				
+9ef77b342	2024-10-10	fixup api thread count comment	api.c	take	core decode/output path (critical)	y				
+87d62d3c9	2024-10-10	readsb service: add CAP_SYS_NICE	debian/readsb.service	take	debian packaging (ADSBx does not fork debian/); keeps deb build current	n				
+431f5d848	2024-10-13	net io: make some code nicer to read	net_io.c	take	core decode/output path (critical)	y				
+e7dec69f0	2024-10-17	speed_check: decrement speedUnreliable speed is unknown	track.c	take	core decode/output path (critical)	y				
+0c87e5932	2024-10-17	incrementing version: 3.14.1642	debian/changelog,version	skip	debian changelog metadata only					
+4f8a0b420	2024-10-29	make --devel=enableClientsJson work	mode_s.c,readsb.c,readsb.h	take	core decode/output path (critical)	y				
+207ec6206	2024-11-01	incrementing version: 3.14.1643	debian/changelog,version	skip	debian changelog metadata only					
+6e2434f1f	2024-11-01	make it simple to save traces without enabling globe-index	6 files: globe_index.c,help.h,json_out.c,readsb.c,readsb.h,stats.c	take	core decode/output path (critical)	y				
+a0ad60b2a	2024-11-01	incrementing version: 3.14.1644	debian/changelog,version	skip	debian changelog metadata only					
+f6c06e581	2024-11-02	first attempt at quick autogain	demod_2400.c,readsb.c,readsb.h,sdr_rtlsdr.c	take	core decode/output path (critical)	y				
+e1b2cecc4	2024-11-02	default to --gain=auto	debian/readsb.default	take	debian packaging (ADSBx does not fork debian/); keeps deb build current	n				
+739f6af7a	2024-11-02	tweak autogain	demod_2400.c,readsb.c,readsb.h,sdr_rtlsdr.c	take	core decode/output path (critical)	y				
+f40bd618d	2024-11-02	allow rtl tuner agc for autogain	6 files: readsb.c,readsb.h,sdr.c,sdr.h,sdr_rtlsdr.c,sdr_rtlsdr.h	take	core code (non-critical) | SDR autogain tuning; not unit-testable, validate on SDR build if used	n				
+e4faf7fa5	2024-11-02	incrementing version: 3.14.1645	debian/changelog,version	skip	debian changelog metadata only					
+1e276882a	2024-11-02	autogain: silent by default	readsb.c,readsb.h,sdr_rtlsdr.c	take	core code (non-critical) | SDR autogain tuning; not unit-testable, validate on SDR build if used	n				
+2c51b73c5	2024-11-02	make quiet autogain the default	README.md,help.h,readsb.c,readsb.h	take	core code (non-critical) | SDR autogain tuning; not unit-testable, validate on SDR build if used	n				
+31378c2ee	2024-11-02	just log 59 dB instead of tuner AGC	sdr_rtlsdr.c	take	SDR/hardware path; low test priority	n				
+80fc54619	2024-11-03	autogain: change default noise thresholds	README.md,readsb.c	take	core code (non-critical) | SDR autogain tuning; not unit-testable, validate on SDR build if used	n				
+8fd5acf09	2024-11-03	autogain: print autogain settings	readsb.c	take	core code (non-critical) | SDR autogain tuning; not unit-testable, validate on SDR build if used	n				
+89fc77451	2024-11-03	autogain defaults tweak	README.md,readsb.c	take	core code (non-critical) | SDR autogain tuning; not unit-testable, validate on SDR build if used	n				
+b4bd2f5c6	2024-11-03	autogain: reduce default loudThreshold	README.md,readsb.c	take	core code (non-critical) | SDR autogain tuning; not unit-testable, validate on SDR build if used	n				
+7be4ddf30	2024-11-03	autogain: faster startup, faster reaction to very loud signals	readsb.c,readsb.h	take	core code (non-critical) | SDR autogain tuning; not unit-testable, validate on SDR build if used	n				
+15823dd47	2024-11-03	autogain: replace startingGain with lowestGain parameter	README.md,readsb.c,readsb.h	take	core code (non-critical) | SDR autogain tuning; not unit-testable, validate on SDR build if used	n				
+c67e6710e	2024-11-04	remove adsbexchange hardcoding	5 files: README.md,help.h,net_io.c,readsb.c,track.c	take	core decode/output path (critical)	y				
+7c34ff39b	2024-11-05	fixup autogain min gain setting	readsb.c,sdr_rtlsdr.c	take	core code (non-critical) | SDR autogain tuning; not unit-testable, validate on SDR build if used	n				
+e8de53682	2024-11-15	add range outline reset via setGain file	readsb.c	take	core code (non-critical) | SDR autogain tuning; not unit-testable, validate on SDR build if used	n				
+079fda30a	2024-11-18	fixup --gain -10	sdr_rtlsdr.c	take	SDR/hardware path; low test priority	n				
+c3214b36f	2024-11-19	longer dwell time for aircraft when writing traces without globe index	track.c	take	core decode/output path (critical)	y				
+2b6338496	2024-12-10	update --net-only help text	help.h,readsb.c	take	core code (non-critical) | help/README text only	n				
+fb8449754	2024-12-10	non rtl-sdr: use default gain when gain=auto passed	readsb.c	take	core code (non-critical) | SDR autogain tuning; not unit-testable, validate on SDR build if used	n				
+9cf1af0a1	2024-12-13	readProxy setting	net_io.c,readsb.c,readsb.h	take	core decode/output path (critical)	y				
+038b48576	2025-01-04	support non-icao addresses in SBS input/output	net_io.c	take	core decode/output path (critical)	y				
+ae987a904	2025-01-04	add comment with SBS sample message	net_io.c	take	core decode/output path (critical)	y				
+7211f3f4c	2025-01-04	improve receiver count logic	track.c	take	core decode/output path (critical)	y				
+2f7a72ed2	2025-01-04	add print to make sure we don't do too many iterations	track.c	take	core decode/output path (critical)	y				
+48ef3c0bd	2025-01-04	github action: fix readsb version to include git commit	.github/workflows/docker.yaml,Dockerfile	take	build/CI only; preserve ADSBx label+workflows | retag->take: build hunks reconciled by tip customization patch			tip-patch	follow-up?	
+3efa2b1ec	2025-01-06	traces: make sure the air ground transition is well recorded	globe_index.c	take	core decode/output path (critical)	y				
+85c087779	2025-01-10	update to world magnetic model 2025 (WMM2025)	geomag.c	take	core code (non-critical) | WMM2025 model: geomag_tests expected values MUST update	y				
+f11a5b8a2	2025-01-10	traces: use buffered position without exception	globe_index.c	take	core decode/output path (critical)	y				
+c373053c1	2025-01-10	incrementing version: 3.14.1646	debian/changelog,version	skip	debian changelog metadata only					
+d3aa1180e	2025-01-21	make tracks statistics consistent across various settings	aircraft.c,track.c	take	core decode/output path (critical)	y				
+06545364d	2025-01-21	ignore non-CRC messages after 30 seconds of last CRC message (was 45)	track.c	take	core decode/output path (critical)	y				
+2f1e4e0be	2025-01-26	only use rtl agc for rafael tuners with 29 gain steps	sdr_rtlsdr.c	take	SDR/hardware path; low test priority	n				
+33a5b080d	2025-01-26	with new arm runners shouldn't need qemu anymore	.github/workflows/docker.yaml	take	build/CI only; preserve ADSBx label+workflows | retag->take: build hunks reconciled by tip customization patch			tip-patch		
+7b76a6a63	2025-01-26	fix rtl-sdr handling for less common tuners	sdr_rtlsdr.c	take	SDR/hardware path; low test priority	n			follow-up?	
+ff6b71adc	2025-02-03	trace saving readme	README.md	skip	upstream docs/release tooling; ADSBx uses own CI/README					
+bf77bfad3	2025-02-06	"Revert ""with new arm runners shouldn't need qemu anymore"""	.github/workflows/docker.yaml	take	build/CI only; preserve ADSBx label+workflows | retag->take: build hunks reconciled by tip customization patch			tip-patch	follow-up?	
+d1b9bc918	2025-02-12	force mlat if no other position	5 files: globe_index.c,readsb.c,readsb.h,track.c,track.h	take	core decode/output path (critical)	y				
+8a2933248	2025-02-13	remove debug print	track.c	take	core decode/output path (critical)	y				
+fc0cab93c	2025-02-13	incrementing version: 3.14.1647	debian/changelog,version	skip	debian changelog metadata only					
+7cbbbe51f	2025-02-14	setLatLon	readsb.c	take	core code (non-critical) | setLatLon affects position/distance output	y				
+b65e1deb3	2025-02-20	sbs_in: don't accept invalid data	net_io.c	take	core decode/output path (critical)	y				
+8d79307e8	2025-02-26	add --process-only	help.h,net_io.c,readsb.c,readsb.h	take	core decode/output path (critical)	y				
+69ea9252d	2025-02-26	heatmap / replay: unknown altitude now allowed	globe_index.c	take	core decode/output path (critical)	y				
+bfc4a0b83	2025-02-27	incrementing version: 3.14.1648	debian/changelog,version	skip	debian changelog metadata only					
+795d69a37	2025-03-06	add config option for beast dump compression level	help.h,readsb.c,readsb.h,util.c	take	core code (non-critical) | beast/SDR serial path; not unit-testable	n				
+8d2c17718	2025-03-06	fixup debug print for autogain	readsb.c	take	core code (non-critical) | debug/log output only	n				
+cc3b5633c	2025-03-06	fix signal emitted via binCraft	globe_index.c,json_out.c,track.c,track.h	take	core decode/output path (critical)	y			follow-up?	
+24c56d024	2025-03-07	change how receiver-focus works	net_io.c	take	core decode/output path (critical)	y				
+21dd45e9e	2025-03-11	add compatibility shims for apple os x	12 files: compat,readsb.h	take	core code (non-critical) | Apple/OSX build-portability shim; n/a to Linux prod	n				
+78580426a	2025-03-11	makefile changes required for os x	Makefile	take	build/CI only; preserve ADSBx label+workflows | retag->take: build hunks reconciled by tip customization patch			tip-patch		
+208f32aa9	2025-03-11	rename task_info_t due to os X name collision	7 files: aircraft.c,globe_index.c,net_io.c,readsb.c,track.c,util.c,util.h	take	core decode/output path (critical)	y				
+81ef113b1	2025-03-11	geomag: suppress unused variable warning	geomag.c,sdr.c	take	core code (non-critical) | debug/log output only	n				
+98824311b	2025-03-11	anet / sdr_beast os x compat	anet.c,globe_index.c,sdr_beast.c	take	core decode/output path (critical)	y				
+55ae341a1	2025-03-11	remove unneded sendfile include	net_io.c	take	core decode/output path (critical)	y				
+3bc551f12	2025-03-11	work without eventfs on darwin	5 files: api.c,compat,net_io.c,readsb.c,util.c	take	core decode/output path (critical)	y				
+a5f3c4009	2025-03-11	make thread join work with apple	readsb.c,util.c	take	core code (non-critical) | Apple/OSX build-portability shim; n/a to Linux prod	n				
+45a9cf12b	2025-03-11	persist a feeder uuid that is given for input net connectors	net_io.c	take	core decode/output path (critical)	y				
+190b152fc	2025-03-11	fixup net connector specified uuid for incoming data	net_io.c	take	core decode/output path (critical)	y				
+ba509868e	2025-03-11	Apple / Mac OS X notes in readme	README.md	skip	upstream docs/release tooling; ADSBx uses own CI/README					
+4d9d72cd5	2025-03-11	incrementing version: 3.14.1649	debian/changelog,version	skip	debian changelog metadata only					
+394a7e374	2025-03-12	os x readme	README.md	skip	upstream docs/release tooling; ADSBx uses own CI/README					
+096df71e2	2025-03-12	more os X readme refinements	README.md	skip	upstream docs/release tooling; ADSBx uses own CI/README					
+0e5dc1197	2025-03-12	create --write-json dir if it doesn't exist	readsb.c,util.c	take	core code (non-critical) | creates --write-json dir; test_output_formats/lifecycle	y				
+856294d2f	2025-03-12	readme wording	README.md	skip	upstream docs/release tooling; ADSBx uses own CI/README					
+2410c5a4d	2025-03-12	macOS homebrew deps	README.md	skip	upstream docs/release tooling; ADSBx uses own CI/README					
+3aba77aa3	2025-03-16	don't disconnect for garbage as quickly unless --net-ingest	net_io.c	take	core decode/output path (critical)	y				
+840e6f433	2025-03-23	improve net connector backoff for fast disconnect	net_io.c	take	core decode/output path (critical)	y				
+b2e12858c	2025-03-23	incrementing version: 3.14.1650	debian/changelog,version	skip	debian changelog metadata only					
+bed4320ca	2025-03-23	fix for fast disconnect round 2	help.h,net_io.c,readsb.c	take	core decode/output path (critical)	y			follow-up?	
+fae312f5a	2025-03-23	incrementing version: 3.14.1651	debian/changelog,version	skip	debian changelog metadata only					
+9add80230	2025-03-26	readme	README.md	skip	upstream docs/release tooling; ADSBx uses own CI/README					
+b42b3c8ef	2025-03-26	make garbage ports work properly on ingest	track.c	take	core decode/output path (critical)	y				
+435bdb8c1	2025-03-28	autogain: fix wrong minimum gain value being printed	readsb.c	take	core code (non-critical) | SDR autogain tuning; not unit-testable, validate on SDR build if used	n			follow-up?	
+4734f21fc	2025-03-30	make rate reduction logic only affect a single connection	net_io.c,net_io.h,readsb.h,track.c	take	core decode/output path (critical)	y				
+1cc309e98	2025-03-30	if the OS network buffer is full, drop every 2nd packet for 1 second	net_io.c	take	core decode/output path (critical)	y				
+e320a64f9	2025-03-30	go to smaller default buffers	help.h,net_io.c,readsb.c,readsb.h	take	core decode/output path (critical)	y				
+9aad5fc69	2025-03-30	simplify flushClient	net_io.c	take	core decode/output path (critical)	y				
+efc9c11c9	2025-03-30	don't spam data discard during tcp scaling window startup	net_io.c	take	core decode/output path (critical)	y				
+0a9730bad	2025-03-31	don't allocate globe index stuff if not needed	globe_index.c,readsb.c	take	core decode/output path (critical)	y				
+5c32b8bc6	2025-03-31	remove unused code	readsb.c,readsb.h	take	core code (non-critical) | cleanup/refactor; no behavior change	n				
+a6691ac8e	2025-03-31	only alloc rangeDirs when needed	5 files: globe_index.c,readsb.c,readsb.h,stats.h,track.c	take	core decode/output path (critical)	y				
+b251391b5	2025-03-31	minor missing cleanup on exit	readsb.c	take	core code (non-critical) | cleanup/refactor; no behavior change	n			follow-up?	
+65904b412	2025-03-31	fix unlikely buffer overflow in apiUpdate / apiAdd	api.c	take	core decode/output path (critical)	y			follow-up?	
+53e773ad0	2025-03-31	change AIRCRAFT_HASH_BITS to a command line argument	8 files: aircraft.c,globe_index.c,help.h,json_out.c,readsb.c,readsb.h,stats.c,track.c	take	core decode/output path (critical)	y				
+171caff26	2025-03-31	only allocate Modes.globeLists when globe-index is used	readsb.c,readsb.h	take	core code (non-critical) | perf/memory; no observable output change	n				
+c5e00ac2c	2025-03-31	incrementing version: 3.14.1652	debian/changelog,version	skip	debian changelog metadata only					
+aaa9bcdb2	2025-04-01	fix network output buffer for json output	net_io.c,net_io.h,readsb.c	take	core decode/output path (critical)	y			follow-up?	
+ea003955c	2025-04-01	incrementing version: 3.14.1653	debian/changelog,version	skip	debian changelog metadata only					
+62f50d5a3	2025-04-01	adjust buffers for large ro-size better	net_io.c,readsb.c	take	core decode/output path (critical)	y				
+b10c89e13	2025-04-01	network buffer comments / debugging switches for flushWrites	help.h,net_io.c,readsb.c	take	core decode/output path (critical)	y				
+032f7c905	2025-04-01	data drop logic: tolerate bad connections better	net_io.c,net_io.h	take	core decode/output path (critical)	y				
+526d789b7	2025-04-01	incrementing version: 3.14.1654	debian/changelog,version	skip	debian changelog metadata only					
+288f2333b	2025-04-01	data drop logic: minor simplification	net_io.c,net_io.h	take	core decode/output path (critical)	y				
+5c4c84fa3	2025-04-01	go back to 5 min interval for showing data drop message	net_io.c	take	core decode/output path (critical)	y				
+e95f68f1f	2025-04-01	incrementing version: 3.14.1655	debian/changelog,version	skip	debian changelog metadata only					
+2e65b0d15	2025-04-01	debugFlush: just show data drop stuff	net_io.c	take	core decode/output path (critical)	y				
+b447a0299	2025-04-01	shorten data drop message	net_io.c	take	core decode/output path (critical)	y				
+9cb2df9ed	2025-04-01	avoid negative lost percentages due to ping bytes	net_io.c	take	core decode/output path (critical)	y				
+3196a7cb4	2025-04-01	once a connection succeeds, do a fresh DNS lookup on reconnect	net_io.c	take	core decode/output path (critical)	y				
+6ec88bffc	2025-04-01	minor free on exit	readsb.c	take	core code (non-critical) | cleanup/refactor; no behavior change	n				
+37137b20d	2025-04-01	don't reuse DNS lookups for 60 seconds	net_io.c	take	core decode/output path (critical)	y				
+4f4fe243e	2025-04-01	incrementing version: 3.14.1656	debian/changelog,version	skip	debian changelog metadata only					
+5f6e635ae	2025-04-02	minor fix for net connect error suppression	net_io.c	take	core decode/output path (critical)	y			follow-up?	
+86d13b608	2025-04-02	remove last_flush logic	net_io.c,net_io.h	take	core decode/output path (critical)	y				
+7f2370080	2025-04-02	getaddrinfo notes	net_io.c	take	core decode/output path (critical)	y				
+329c86637	2025-04-02	net connector: ignore 0.0.0.0 and :: as DNS replies	net_io.c	take	core decode/output path (critical)	y				
+40c15cbcd	2025-04-02	slow down connect attempts for multiple DNS results	net_io.c	take	core decode/output path (critical)	y				
+88be759a5	2025-04-03	binCraft: improve rssi representation	aircraft.c,readsb.c,track.h	take	core decode/output path (critical)	y				
+aeb54398f	2025-04-03	slight cpu reduction: ground track calculation: use atan2f instead of atan	mode_s.c,net_io.c	take	core decode/output path (critical)	y				
+2b5abcc6d	2025-04-03	minor cpu savings in greatcircle calc	util.c	take	core code (non-critical) | greatcircle distance calc change; util_tests	y				
+2bd9d41d0	2025-04-03	move stuff around, mess with bearing function a bit	track.h,util.c,util.h	take	core decode/output path (critical)	y				
+175bf2472	2025-04-07	fixup make test	Makefile,readsb.h	take	core code (non-critical) + touches build (resolve to ADSBx side) | fixes make test target itself; test plumbing not new coverage | retag->take: build hunks reconciled by tip customization patch	n		tip-patch		
+a38449fea	2025-04-07	deb build: no need to set non-default hash bits anymore	debian/rules	take	debian packaging (ADSBx does not fork debian/); keeps deb build current	n				
+e97ea0e47	2025-04-14	incrementing version: 3.14.1657	debian/changelog,version	skip	debian changelog metadata only					
+4bd63b8d1	2025-04-17	ignore DF types with icao CRC quicker after receiving zero CRC	track.c	take	core decode/output path (critical)	y				
+6ede38d98	2025-04-17	unify place where sockopts are set, set TCP_NODELAY	net_io.c	take	core decode/output path (critical)	y				
+1a58f4eae	2025-04-18	fix net receiver id forwarding	net_io.c	take	core decode/output path (critical)	y			follow-up?	
+1355d9b10	2025-04-18	incrementing version: 3.14.1658	debian/changelog,version	skip	debian changelog metadata only					
+56e653342	2025-04-19	somewhat dynamically resize receiver table	net_io.c,readsb.c,receiver.c	take	core decode/output path (critical)	y				
+ebcd1e04e	2025-04-19	improve reduce_forward for quickly alternating squawk	track.c	take	core decode/output path (critical)	y				
+3fa691e3f	2025-04-19	ingest: remove unreasonably high message rate clients	net_io.c,net_io.h,readsb.c,readsb.h	take	core decode/output path (critical)	y				
+151e73638	2025-04-19	incrementing version: 3.14.1659	debian/changelog,version	skip	debian changelog metadata only					
+72b024a94	2025-04-19	slightly more reliably send position messages often for beast reduce logic	track.c,track.h	take	core decode/output path (critical)	y				
+f819fa3e8	2025-04-19	incrementing version: 3.14.1660	debian/changelog,version	skip	debian changelog metadata only					
+d43d7d814	2025-04-19	make quickGet slightly quicker	aircraft.c	take	core decode/output path (critical)	y				
+0ec418431	2025-04-20	don't warn as strictly about save_blob duration	readsb.c	take	core code (non-critical) | debug/log output only	n				
+6d0c20682	2025-04-24	nogrind.sh gdb	nogrind.sh	skip	upstream docs/release tooling; ADSBx uses own CI/README					
+2ef2b0b37	2025-04-24	add some rarely useful debug code	track.c	take	core decode/output path (critical)	y				
+ce8575d36	2025-04-24	prevent emitting old data after client disconnect / connect	net_io.c	take	core decode/output path (critical)	y				
+08484db8c	2025-04-24	debug tweaks	track.c	take	core decode/output path (critical)	y				
+8660f1f65	2025-04-24	traceLast no output	globe_index.c,readsb.c,readsb.h,track.h	take	core decode/output path (critical)	y				
+e9a6ea0bd	2025-04-24	use traceLast to add granular data to full and history traces	globe_index.c,json_out.c,json_out.h,readsb.c	take	core decode/output path (critical)	y				
+1c3209739	2025-04-24	with SDR: more consistently forward messages	net_io.c	take	core decode/output path (critical)	y				
+7aedf5d32	2025-04-24	incrementing version: 3.14.1661	debian/changelog,version	skip	debian changelog metadata only					
+44c867fff	2025-04-25	traceLast: don't write extra data to json if aircraft still active	json_out.c	take	core decode/output path (critical)	y				
+e64d45b1e	2025-04-25	incrementing version: 3.14.1662	debian/changelog,version	skip	debian changelog metadata only					
+5a6dd3a71	2025-04-25	comment	json_out.c	take	core decode/output path (critical)	y				
+fcde5abac	2025-04-26	try other IPs from DNS for instant disconnect	net_io.c	take	core decode/output path (critical)	y				
+b16bffc56	2025-04-26	globe-index traces: reduce /run memory usage for inactive aircraft	globe_index.c	take	core decode/output path (critical)	y				
+bfc8b2e70	2025-04-26	add ignore_synthetic	net_io.c,readsb.c,readsb.h	take	core decode/output path (critical)	y				
+a42c4c0f9	2025-04-26	accept_synthetic disconnect: hexdump some data	net_io.c	take	core decode/output path (critical)	y				
+f90e746e2	2025-04-26	incrementing version: 3.14.1663	debian/changelog,version	skip	debian changelog metadata only					
+1a7b5d4b7	2025-04-26	typo	net_io.c	take	core decode/output path (critical)	y			follow-up?	
+be6d87b6c	2025-04-26	beast dump timestamp handling: better defaults	net_io.c	take	core decode/output path (critical)	y				
+3b6eab568	2025-04-26	reduce trace memory usage	globe_index.c,readsb.c	take	core decode/output path (critical)	y				
+9fce12946	2025-04-26	comment on extening zstd data	globe_index.c	take	core decode/output path (critical)	y				
+a42b149ed	2025-04-26	debug output	globe_index.c	take	core decode/output path (critical)	y				
+b66f00cd4	2025-04-26	more consistently extend traceChunks	globe_index.c	take	core decode/output path (critical)	y				
+60ee90632	2025-04-26	recompress trace chunks for a bit of memory saving	globe_index.c,track.h	take	core decode/output path (critical)	y				
+b0865e9d2	2025-04-26	traceChunk logic: better deal with inactive timespans in traces	globe_index.c	take	core decode/output path (critical)	y				
+0ae0a51cc	2025-04-27	recompressStateChunk: more statistics	globe_index.c	take	core decode/output path (critical)	y				
+1a6822689	2025-04-27	trace heuristic: more resolution for altitude changes	globe_index.c	take	core decode/output path (critical)	y				
+72b20df84	2025-04-27	incrementing version: 3.14.1664	debian/changelog,version	skip	debian changelog metadata only					
+6b04939a0	2025-04-28	minor tracechunk logic improvement	globe_index.c	take	core decode/output path (critical)	y				
+de411030e	2025-04-28	stateChunk: specify int size	track.h	take	core decode/output path (critical)	y				
+3dbbe4a2c	2025-04-28	fix rare occurrence of recent trace missing after initial trace write	globe_index.c,json_out.c,readsb.c	take	core decode/output path (critical)	y			follow-up?	
+86533e82c	2025-04-28	traceLastNext shuffle	globe_index.c	take	core decode/output path (critical)	y				
+f7c66f496	2025-04-28	incrementing version: 3.14.1665	debian/changelog,version	skip	debian changelog metadata only					
+f3ceb3d35	2025-04-28	cleanup trace dir creation a little bit	globe_index.c	take	core decode/output path (critical)	y				
+ff6da7c29	2025-04-29	conditional deactivation of recompression	globe_index.c,readsb.c	take	core decode/output path (critical)	y				
+cc3f1fc19	2025-04-30	debug cleanup	globe_index.c	take	core decode/output path (critical)	y				
+327fd6f0a	2025-04-30	reduce frequency of permanent trace writes	globe_index.c,globe_index.h,json_out.c	take	core decode/output path (critical)	y				
+cac81e77d	2025-04-30	proper receiver count for aircraft without position	track.c,track.h	take	core decode/output path (critical)	y				
+ee9f94041	2025-04-30	incrementing version: 3.14.1666	debian/changelog,version	skip	debian changelog metadata only					
+9705fc674	2025-04-30	trace writing: make it easier to see different trace writes in flame graphs	globe_index.c	take	core decode/output path (critical)	y				
+abc0201bd	2025-04-30	makefile add LTO option	Makefile	take	build/CI only; preserve ADSBx label+workflows | retag->take: build hunks reconciled by tip customization patch			tip-patch		
+bbf446ad0	2025-05-01	improve help for --device-type ifile	README.md,help.h	take	core code (non-critical) | help/README text only	n				
+cb2f04a9e	2025-05-01	incrementing version: 3.14.1667	debian/changelog,version	skip	debian changelog metadata only					
+89de90c10	2025-05-01	add example for simple webserver to MacOS instructions	README.md	skip	upstream docs/release tooling; ADSBx uses own CI/README					
+a22572a89	2025-05-01	trace stuff cleanup / soften midnight IOPS spike	globe_index.c	take	core decode/output path (critical)	y				
+1ac848953	2025-05-01	api buffer minor tweak	api.c	take	core decode/output path (critical)	y				
+38be34f18	2025-05-01	make api hash automatically resize to save 4MB of memory for most installs	api.c,api.h	take	core decode/output path (critical)	y				
+8311b5345	2025-05-01	fixup filter_callsign API / cleanup some bad constants in api code	api.c,api.h,util.h	take	core decode/output path (critical)	y				
+0b495c588	2025-05-02	incrementing version: 3.14.1668	debian/changelog,version	skip	debian changelog metadata only					
+8cac43bcd	2025-05-02	getUptime: never use synthetic timestamp	util.c	take	core code (non-critical) | getUptime no synthetic ts; stats output	y				
+3df53b3ab	2025-05-02	use mmap to take advantage of 2MB (or multiple) mappings that are automatically 	readsb.c,readsb.h	take	core code (non-critical) | perf/memory; no observable output change	n				
+a59431f1a	2025-05-05	only write permanent traces near the end of the day	globe_index.c,globe_index.h	take	core decode/output path (critical)	y				
+4e320be84	2025-05-05	use mmap for aircraft object storage under certain conditions	7 files: aircraft.c,aircraft.h,globe_index.c,globe_index.h,readsb.c,readsb.h,track.h	take	core decode/output path (critical)	y				
+d76bf09b1	2025-05-05	keep track of memory used for aircraft structs	aircraft.c,massif.sh,readsb.h,stats.c	take	core decode/output path (critical)	y				
+61d5566fb	2025-05-05	parallel state loading aircraftCreate: explain why we don't need a mutex for thi	aircraft.c,readsb.c,readsb.h	take	core decode/output path (critical)	y				
+cdf22bb46	2025-05-05	better maintain quickGet	aircraft.c,track.c	take	core decode/output path (critical)	y				
+b43a43d6a	2025-05-05	add spinlock, don't use it though	5 files: aircraft.c,readsb.c,readsb.h,util.c,util.h	take	core decode/output path (critical)	y				
+46ad2fc16	2025-05-05	readme / help: use file instead filepath	README.md,help.h	take	core code (non-critical) | help/README text only	n				
+301aa03cb	2025-05-05	incrementing version: 3.14.1669	debian/changelog,version	skip	debian changelog metadata only					
+3edb4e7b7	2025-05-06	use aircraftBack to reduce memory fragmentation even without thp	aircraft.c	take	core decode/output path (critical)	y				
+50b2a290c	2025-05-06	incrementing version: 3.14.1670	debian/changelog,version	skip	debian changelog metadata only					
+7423fcc45	2025-05-06	add free on exit for valgrind	aircraft.c,readsb.c	take	core decode/output path (critical)	y				
+9e5d95f7c	2025-05-06	save 4 MB of memory when using --db-file	readsb.h	take	core code (non-critical) | perf/memory; no observable output change	n				
+266ce73db	2025-05-06	fix minor memory stat issue	aircraft.c	take	core decode/output path (critical)	y			follow-up?	
+33cd3b4b3	2025-05-07	work around global data with ground positions while a receiver location is provi	readsb.c,readsb.h,track.c	take	core decode/output path (critical)	y				
+601d52bfd	2025-05-10	better logging when using ModeS Beast	net_io.c	take	core decode/output path (critical)	y				
+af0982436	2025-05-11	reset aircraft message count when it's been inactive for 15 minutes	track.c	take	core decode/output path (critical)	y				
+09a1f5bff	2025-05-11	fixup global message rate calculation	track.c	take	core decode/output path (critical)	y				
+d280b540f	2025-05-11	incrementing version: 3.14.1671	debian/changelog,version	skip	debian changelog metadata only					
+5bf3030c9	2025-05-11	thread pool buffers: release regularly	readsb.c,threadpool.c,util.c	take	core code (non-critical) | perf/memory; no observable output change	n				
+d63f888a6	2025-05-11	remove unused minilzo dependency	Makefile,globe_index.c,readsb.c,readsb.h	take	core decode/output path (critical) + touches build (resolve to ADSBx side) | retag->take: build hunks reconciled by tip customization patch	y		tip-patch		
+940d7ff52	2025-05-11	remove minizlo dependency: code folder	8 files: minilzo	take	vendored lib only	n				
+9ee3e116e	2025-05-12	netDrainMessageBuffers: drain all of them	net_io.c	take	core decode/output path (critical)	y				
+6a9f6432c	2025-05-12	add baudrate, cosmetics	sdr.c,sdr_beast.c	take	core code (non-critical) | beast/SDR serial path; not unit-testable	n				
+ece78830a	2025-05-12	mode-s beast: hopefully fix baud setting	compat/apple/serial_compat.h,help.h,sdr_beast.c	take	core code (non-critical) | beast/SDR serial path; not unit-testable	n			follow-up?	
+1db569169	2025-05-12	incrementing version: 3.14.1672	debian/changelog,version	skip	debian changelog metadata only					
+f7c42168e	2025-05-22	some unused code to print bar graph on console for message rate	track.c	take	core decode/output path (critical)	y				
+9d95f40ee	2025-05-22	--full-trace-dir option to reduce memory usage of --write-globe-index at the exp	globe_index.c,help.h,readsb.c,readsb.h	take	core decode/output path (critical)	y				
+7ecb58dcd	2025-05-23	incrementing version: 3.14.1673	debian/changelog,version	skip	debian changelog metadata only					
+c677ad243	2025-05-23	docker jemalloc: slight memory savings	Dockerfile	take	build/CI only; preserve ADSBx label+workflows | retag->take: build hunks reconciled by tip customization patch			tip-patch		
+aff96e812	2025-05-23	incrementing version: 3.14.1674	debian/changelog,version	skip	debian changelog metadata only					
+2002728ea	2025-05-23	don't mess with trace_next_perm on load	globe_index.c	take	core decode/output path (critical)	y				
+94ac38dc6	2025-05-23	try and spread out perm writes better	globe_index.c	take	core decode/output path (critical)	y				
+a06500910	2025-05-24	better update receiverlist for receivers that are not quite as low latency	track.c	take	core decode/output path (critical)	y				
+05408c530	2025-05-24	add some thread count limits	api.c,globe_index.c,readsb.c	take	core decode/output path (critical)	y				
+7153cbe14	2025-05-24	incrementing version: 3.14.1675	debian/changelog,version	skip	debian changelog metadata only					
+d3eb56779	2025-05-24	better way to set priority for trace pool	readsb.c	take	core code (non-critical) | perf/memory; no observable output change	n				
+669cdca11	2025-05-24	traces: add version string	Makefile,json_out.c	take	core decode/output path (critical) + touches build (resolve to ADSBx side) | retag->take: build hunks reconciled by tip customization patch	y		tip-patch		
+eb117e317	2025-05-26	fine grained ground positions if speed changes	globe_index.c	take	core decode/output path (critical)	y				
+aa7a40fd6	2025-05-26	add 30 seconds of max resolution before landing	globe_index.c	take	core decode/output path (critical)	y				
+c9780a584	2025-05-26	higher resolution for 30 seconds after airground change	globe_index.c,track.c,track.h	take	core decode/output path (critical)	y				
+a470d6051	2025-05-26	"Revert ""better update receiverlist for receivers that are not quite as low laten"	track.c	take	core decode/output path (critical)	y			follow-up?	
+86d599842	2025-05-26	fine grained ground positions if speed changes not that great remove	globe_index.c	take	core decode/output path (critical)	y				
+688111f15	2025-05-26	incrementing version: 3.14.1676	debian/changelog,version	skip	debian changelog metadata only					
+ffd36f5dc	2025-05-27	improve non position data reduce forwarding for --net-ingest instances	track.c	take	core decode/output path (critical)	y				
+4a77ba19f	2025-05-27	incrementing version: 3.14.1677	debian/changelog,version	skip	debian changelog metadata only					
+a2856a18e	2025-05-27	regularly reallocate certain buffers	globe_index.c	take	core decode/output path (critical)	y				
+d0df62f24	2025-05-27	better debugging / allow more compressCurrent passes	globe_index.c	take	core decode/output path (critical)	y				
+e5a4fe909	2025-05-27	autogain: recover gain much quicker	readsb.c	take	core code (non-critical) | SDR autogain tuning; not unit-testable, validate on SDR build if used	n				
+3862d1d5a	2025-05-27	autogain: much quicker rebound for closeby passing aircraft	readsb.c	take	core code (non-critical) | SDR autogain tuning; not unit-testable, validate on SDR build if used	n				
+ecdf45ffe	2025-05-27	incrementing version: 3.14.1678	debian/changelog,version	skip	debian changelog metadata only					
+a28302c32	2025-05-27	writing fulltrace: always mark legs	globe_index.c	take	core decode/output path (critical)	y				
+1ecee5743	2025-05-28	autogain loud rebound: not quite as fast	readsb.c	take	core code (non-critical) | SDR autogain tuning; not unit-testable, validate on SDR build if used	n				
+65dfd86a9	2025-05-28	incrementing version: 3.14.1679	debian/changelog,version	skip	debian changelog metadata only					
+9f6e870c4	2025-05-28	add lock around some trace handling	globe_index.c,track.h	take	core decode/output path (critical)	y				
+a2e98afe9	2025-05-28	some more traceLock	track.c	take	core decode/output path (critical)	y				
+e77bb4e3d	2025-05-28	remove incorrect comment	track.c	take	core decode/output path (critical)	y				
+1a9629f21	2025-05-28	removestale: iterate all aircraft less often	track.c	take	core decode/output path (critical)	y				
+3bf279d9e	2025-05-28	no traceMaintenance calls unless needed	track.c	take	core decode/output path (critical)	y				
+60bb6ec89	2025-05-28	debug stuff	track.c	take	core decode/output path (critical)	y				
+605e0aade	2025-05-30	fixup some trace logic things	globe_index.c,readsb.c,readsb.h	take	core decode/output path (critical)	y				
+cd775cba7	2025-05-30	increase traceLast default to 96	readsb.c	take	core code (non-critical) | perf/memory; no observable output change (validate default change in dev)	n	y			
+04454843b	2025-05-30	after landing / takeoff: up to 60 seconds of data every second	globe_index.c,readsb.c,readsb.h	take	core decode/output path (critical)	y				
+4e4c61f08	2025-05-30	incrementing version: 3.14.1680	debian/changelog,version	skip	debian changelog metadata only					
+5faf09687	2025-06-02	binCraft: better switching between message rate and message count	json_out.c,readsb.h,stats.c	take	core decode/output path (critical)	y				
+f2b6d3f29	2025-06-02	incrementing version: 3.14.1681	debian/changelog,version	skip	debian changelog metadata only					
+67614a236	2025-06-02	binCraft messagerate fixup	api.c,json_out.c	take	core decode/output path (critical)	y				
+04b69dfd0	2025-06-02	incrementing version: 3.14.1682	debian/changelog,version	skip	debian changelog metadata only					
+554a17ded	2025-06-02	reference homebrew recipe	README.md	skip	upstream docs/release tooling; ADSBx uses own CI/README					
+c7a309b62	2025-06-18	when using an SDR only forward first message from a plane when no fixed bits	net_io.c	take	core decode/output path (critical)	y				
+600772272	2025-06-18	incrementing version: 3.14.1683	debian/changelog,version	skip	debian changelog metadata only					
+75decb53c	2025-06-19	don't delay using jaero positions when low jaero timeout set	track.c	take	core decode/output path (critical)	y				
+f583afe8e	2025-06-27	write full traces less often	Makefile,globe_index.c,globe_index.h	take	core decode/output path (critical) + touches build (resolve to ADSBx side) | retag->take: build hunks reconciled by tip customization patch	y		tip-patch		
+85d434726	2025-07-01	tweak autogain: make single loudEvent sufficient to reduce gain	readsb.c	take	core code (non-critical) | SDR autogain tuning; not unit-testable, validate on SDR build if used	n				
+452cb976c	2025-07-01	incrementing version: 3.14.1684	debian/changelog,version	skip	debian changelog metadata only					
+5073f10c7	2025-07-10	improve altitude reliability check	track.c	take	core decode/output path (critical)	y				
+60f296747	2025-07-10	incrementing version: 3.14.1685	debian/changelog,version	skip	debian changelog metadata only					
+554fd755d	2025-07-10	minor fixup for altitude reliability check	track.c	take	core decode/output path (critical)	y				
+12edce9a4	2025-07-10	don't disrupt alt_reliable due to disagreeing lower quality data	track.c	take	core decode/output path (critical)	y				
+92be7701c	2025-07-10	accept alt from mlat sbs input	track.c	take	core decode/output path (critical)	y				
+62e6cb294	2025-07-10	minor alt update stuff	track.c	take	core decode/output path (critical)	y				
+8740084e0	2025-07-10	incrementing version: 3.14.1686	debian/changelog,version	skip	debian changelog metadata only					
+81f5293ba	2025-07-10	debug stuff	track.c	take	core decode/output path (critical)	y				
+8b495ebdf	2025-07-10	alt update minor	track.c	take	core decode/output path (critical)	y				
+8087d37a4	2025-07-11	json mlat / tisb flags array: add alt_baro	json_out.c	take	core decode/output path (critical)	y				
+ac891f8a4	2025-07-11	incrementing version: 3.14.1687	debian/changelog,version	skip	debian changelog metadata only					
+6d4bb7302	2025-07-12	altitude update debugging stuff	track.c	take	core decode/output path (critical)	y				
+e6ed99481	2025-07-12	readme	README-json.md	skip	upstream docs/release tooling; ADSBx uses own CI/README					
+b1487aca5	2025-07-15	--gain=auto: increase default noiseLowThreshold a bit	README.md,readsb.c	take	core code (non-critical) | SDR autogain tuning; not unit-testable, validate on SDR build if used	n				
+3b501c105	2025-07-15	incrementing version: 3.14.1688	debian/changelog,version	skip	debian changelog metadata only					
+451221d54	2025-07-15	autogain: debounce loudRebound a bit	readsb.c	take	core code (non-critical) | SDR autogain tuning; not unit-testable, validate on SDR build if used	n				
+bf82d5c76	2025-07-15	incrementing version: 3.14.1689	debian/changelog,version	skip	debian changelog metadata only					
+9cb37df8a	2025-07-15	incrementing version: 3.14.1690	debian/changelog,version	skip	debian changelog metadata only					
+77296c980	2025-07-20	net_io: use global ais_charset definition	net_io.c	take	core decode/output path (critical)	y				
+f743b90e7	2025-07-20	ais_charset, uat2esnt: ensure ais_charset is a NUL-terminated string	ais_charset.c,ais_charset.h,uat2esnt/uat2esnt.c	take	core code (non-critical) | ais_charset NUL-termination; ais_charset_tests	y				
+dab71ee4a	2025-07-20	interactive, uat2esnt: use __nonstring__ attribute for byte arrays	interactive.c,readsb.h,uat2esnt/uat.h,uat2esnt/uat_decode.c	take	core code (non-critical) | cleanup/refactor; no behavior change	n				
+21d399deb	2025-07-21	extend char arrays to avoid unterminated strings	interactive.c,readsb.h,uat2esnt/uat.h,uat2esnt/uat_decode.c	take	core code (non-critical) | cleanup/refactor; no behavior change	n				
+58040bfe4	2025-07-28	parse SBS receive timestamp	net_io.c	take	core decode/output path (critical)	y				
+71e4a7dee	2025-07-28	incrementing version: 3.14.1691	debian/changelog,version	skip	debian changelog metadata only					
+b8250c42e	2025-07-28	readme: link some projects using this software	README.md	skip	upstream docs/release tooling; ADSBx uses own CI/README					
+86f2be0db	2025-07-28	sbs input: prevent parsing timestamps from the future	net_io.c	take	core decode/output path (critical)	y				
+45b6ec3c4	2025-08-01	clear range outline as expected when no data is coming in	track.c	take	core decode/output path (critical)	y				
+48449b0a2	2025-08-01	incrementing version: 3.14.1692	debian/changelog,version	skip	debian changelog metadata only					
+28f664663	2025-08-02	fixup SBS time parsing	net_io.c	take	core decode/output path (critical)	y				
+c42e66d3b	2025-08-02	incrementing version: 3.14.1693	debian/changelog,version	skip	debian changelog metadata only					
+2fac6025b	2025-08-10	traces: fix roll overflow by reducing accuracy	track.h	take	core decode/output path (critical)	y			follow-up?	
+3a91797ab	2025-08-10	incrementing version: 3.14.1694	debian/changelog,version	skip	debian changelog metadata only					
+5a3d6f2ac	2025-08-14	make json location accuracy work more reliably on indirect data	help.h,json_out.c,readsb.c,readsb.h	take	core decode/output path (critical)	y				
+3c337324c	2025-08-14	incrementing version: 3.14.1695	debian/changelog,version	skip	debian changelog metadata only					
+25eb72f0d	2025-08-15	viewadsb: improve altitude sorting stability	interactive.c	take	core code (non-critical) | viewadsb/interactive terminal UI; not in automated suite	n				
+4493ff430	2025-08-15	viewadsb: only sort every 3 seconds	interactive.c	take	core code (non-critical) | viewadsb/interactive terminal UI; not in automated suite	n				
+f4d29c888	2025-08-15	reduce viewadsb refresh from 0.25 to 0.5 seconds	readsb.h	take	core code (non-critical) | viewadsb/interactive terminal UI; not in automated suite	n				
+74f2d9d01	2025-08-15	viewadsb: only clear errors every 10 seconds	interactive.c	take	core code (non-critical) | viewadsb/interactive terminal UI; not in automated suite	n				
+0867262d9	2025-08-15	add support for uat messages encapsulated in the beast stream	net_io.c	take	core decode/output path (critical)	y				
+130c6f47c	2025-08-15	read_uuid in beast stream: handle partial buffer correctly	net_io.c	take	core decode/output path (critical)	y				
+2ff826d46	2025-08-15	incrementing version: 3.14.1696	debian/changelog,version	skip	debian changelog metadata only					
+234dad576	2025-08-15	fixup encapsulated UAT	net_io.c	take	core decode/output path (critical)	y				
+de952d873	2025-08-15	interactive: speed 4 wide for --metric	interactive.c	take	core code (non-critical) | viewadsb/interactive terminal UI; not in automated suite	n				
+b6c96747b	2025-08-15	interactive: consistently sort ground	interactive.c	take	core code (non-critical) | viewadsb/interactive terminal UI; not in automated suite	n				
+eaa4085fa	2025-08-15	interactive: when lat lon specified, show distance / direction and sort by dista	interactive.c	take	core code (non-critical) | viewadsb/interactive terminal UI; not in automated suite	n				
+c77b06279	2025-08-15	interactive minor readability changes	interactive.c	take	core code (non-critical) | viewadsb/interactive terminal UI; not in automated suite	n				
+539e11d46	2025-08-15	interactive sort stability for aircraft on ground	interactive.c	take	core code (non-critical) | viewadsb/interactive terminal UI; not in automated suite	n				
+9c55bcdd6	2025-08-17	debian rules	debian/control,debian/rules	take	debian packaging (ADSBx does not fork debian/); keeps deb build current	n				
+63acbde9e	2025-08-17	incrementing version: 3.14.1697	debian/changelog,version	skip	debian changelog metadata only					
+e70292810	2025-08-17	big version jump: 3.15	tag.sh,version	skip	upstream docs/release tooling; ADSBx uses own CI/README					
+b60583a85	2025-08-17	incrementing version: 3.15.1	debian/changelog,version	skip	debian changelog metadata only					
+32c0ced0d	2025-08-17	specify build dep libsoapysdr-dev in readme	README.md	skip	upstream docs/release tooling; ADSBx uses own CI/README					
+e1ec52c42	2025-08-18	build with all the SDR support	README.md,debian/control,debian/rules	adapt	debian SDR build profile may affect dpkg-buildpackage -Prtlsdr; verify			verify-packaging		
+5b1e05c97	2025-08-18	update debian copyright at least partially	debian/copyright	take	debian packaging (ADSBx does not fork debian/); keeps deb build current	n				
+ea1e279a2	2025-08-18	debian package: build faster with make -j $(nprocs)	debian/rules	take	debian packaging (ADSBx does not fork debian/); keeps deb build current	n				
+ce09d1aeb	2025-08-18	cleanup readsb.service / readsb.default	debian/readsb.default,debian/readsb.service	take	debian packaging (ADSBx does not fork debian/); keeps deb build current	n				
+878763238	2025-08-18	update debian package description	debian/control	take	debian packaging (ADSBx does not fork debian/); keeps deb build current	n				
+548ecb269	2025-08-18	readme: add some credits / history	README.md	skip	upstream docs/release tooling; ADSBx uses own CI/README					
+dd59d1d76	2025-08-18	autogenerate manpages using help2man	debian/control,debian/readsb.1,debian/rules,debian/viewadsb.1	take	debian packaging (ADSBx does not fork debian/); keeps deb build current	n				
+26d725d3e	2025-08-18	print some credits in help	argp.c,argp.h,help.h	take	core code (non-critical) | help/README text only	n				
+798f32f04	2025-08-18	incrementing version: 3.15.2	debian/changelog,version	skip	debian changelog metadata only					
+604042f18	2025-08-18	readme: update build instructions	README.md	skip	upstream docs/release tooling; ADSBx uses own CI/README					
+4e38f3123	2025-08-18	more flexible tag.sh	changelog,tag.sh	skip	upstream docs/release tooling; ADSBx uses own CI/README					
+7ef806ab6	2025-08-18	tag.sh: add notes for releasing a version	tag.sh	skip	upstream docs/release tooling; ADSBx uses own CI/README					
+1a51ad707	2025-08-18	fixup tag.sh to include changelog from main directory	tag.sh	skip	upstream docs/release tooling; ADSBx uses own CI/README					
+9a962dc10	2025-08-18	tag.sh add newline after unreleased changelog entry	tag.sh	skip	upstream docs/release tooling; ADSBx uses own CI/README					
+b0e673bef	2025-08-18	add with_sdrs build profile	README.md,debian/control,debian/rules	adapt	debian SDR build profile may affect dpkg-buildpackage -Prtlsdr; verify			verify-packaging		
+6927c3579	2025-08-18	release 3.16	changelog,debian/changelog,version	skip	upstream docs/release tooling; ADSBx uses own CI/README					
+41bde73c0	2025-08-18	readme: fixup missing help2man dependency	README.md	skip	upstream docs/release tooling; ADSBx uses own CI/README				follow-up?	
+57e1c0b0e	2025-08-27	load_state: somewhat better handling of broken state data	6 files: aircraft.c,aircraft.h,globe_index.c,globe_index.h,readsb.c,readsb.h	take	core decode/output path (critical)	y				
+5d6ce7a0d	2025-08-27	aircraft loading: can't rely on blob association staying the same	globe_index.c,readsb.c,readsb.h	take	core decode/output path (critical)	y				
+05c70f90d	2025-08-27	dealing with messed up state is tricky	globe_index.c	take	core decode/output path (critical)	y				
+0cea2aa2e	2025-08-27	incrementing version: 3.16.1	debian/changelog,version	skip	debian changelog metadata only					
+e4bf34081	2025-08-31	remove unnecessarly newlines from ownOp/year details in json	json_out.c	take	core decode/output path (critical)	y				
+5950f7448	2025-09-06	increase output buffer for uat2esnt conversion	net_io.c	take	core decode/output path (critical)	y				
+44daf02ff	2025-09-06	add ugly way to process specially beast encapsulated UAT messages	net_io.c	take	core decode/output path (critical)	y				
+990bafb14	2025-09-06	minor stuff to more obviously guarantee progress processing beast	net_io.c	take	core decode/output path (critical)	y				
+7335e0c01	2025-09-08	distance approximation: go back to elliptical earth	util.c	take	core code (non-critical) | distance calc back to elliptical earth; util_tests	y				
+460c9fc6b	2025-09-08	distance approximations aren't that good, less noisy when checking approx	util.c	take	core code (non-critical) | debug/log output only	n				
+3852ad21e	2025-09-08	less noisy checking degree approx	util.c	take	core code (non-critical) | debug/log output only	n				
+786c1ac79	2025-09-09	prevent traceLast data from the previous day in history traces	globe_index.c,json_out.c,json_out.h	take	core decode/output path (critical)	y				
+4c1459a82	2025-09-10	incrementing version: 3.16.2	debian/changelog,version	skip	debian changelog metadata only					
+6ee71cfaa	2025-09-25	debug for decodeEncapsulatedUAT	net_io.c	take	core decode/output path (critical)	y				
+3623c68f0	2025-09-25	decodeEncapsulatedUat: fix, this should work now	net_io.c	take	core decode/output path (critical)	y			follow-up?	
+03a2bf526	2025-09-25	incrementing version: 3.16.3	debian/changelog,version	skip	debian changelog metadata only					
+ec69dc129	2025-10-06	receiver position logic: fix for receivers near dateline	receiver.c	take	core decode/output path (critical)	y			follow-up?	
+14ef1565b	2025-10-06	prepare defines for api filtering by uuid	Makefile,readsb.h,track.c,track.h	take	core decode/output path (critical) + touches build (resolve to ADSBx side) | retag->take: build hunks reconciled by tip customization patch	y		tip-patch		
+e213c054d	2025-10-06	api: add &filter_uuid filter	README-json.md,api.c,api.h	take	core decode/output path (critical)	y				
+55b026baf	2025-10-07	only show planes with filter_uuid if received very recently by uuid	api.c	take	core decode/output path (critical)	y				
+b530dd30e	2025-10-14	comment on dropHalfUntil	net_io.c	take	core decode/output path (critical)	y				
+83cfa54e1	2025-10-17	adjust help for TCP client / server terminology	help.h	take	core code (non-critical) | help/README text only	n				
+9b80d7208	2025-10-17	update --help in github readme	README.md	skip	upstream docs/release tooling; ADSBx uses own CI/README					
+af4d2d6a0	2025-10-17	incrementing version: 3.16.4	debian/changelog,version	skip	debian changelog metadata only					
+b53e58c1c	2025-10-20	stop counting invalid decodes from network for message rate	track.c	take	core decode/output path (critical)	y				
+3e095b1f1	2025-10-20	incrementing version: 3.16.5	debian/changelog,version	skip	debian changelog metadata only					
+7b78f77f0	2025-11-07	readme: fixup a link	README.md	skip	upstream docs/release tooling; ADSBx uses own CI/README					
+81b5d26ff	2025-11-10	ifile: exit promptly	sdr_ifile.c	take	SDR/hardware path; low test priority	n				
+079768749	2025-11-10	improve handling of synthetic clock / priority tasks	readsb.c,readsb.h,sdr_ifile.c	take	core code (non-critical) | synthetic clock/priority affects ifile replay determinism in tests	y	y			
+2d007af3c	2025-11-10	interactive: clean up seen column formatting a bit	interactive.c	take	core code (non-critical) | viewadsb/interactive terminal UI; not in automated suite	n				
+97ba5e692	2025-11-15	modify default USB buffer size to 128 kibibytes	help.h,readsb.c	take	core code (non-critical) | perf/memory; no observable output change	n				
+aa0bc6286	2025-11-15	SDR: unexpected size: avoid spamming the log too much	sdr_hackrf.c,sdr_plutosdr.c,sdr_rtlsdr.c,sdr_soapy.c	take	SDR/hardware path; low test priority	n				
+b985831f5	2025-11-15	incrementing version: 3.16.6	debian/changelog,version	skip	debian changelog metadata only					
+ba29158f0	2025-11-20	add option --json-separate-alt-ground	help.h,json_out.c,readsb.c,readsb.h	take	core decode/output path (critical)	y				
+feee9307e	2025-12-14	make --net-beast-reduce-filter-dist more versatile	help.h,readsb.c,track.c	take	core decode/output path (critical)	y				
+6946bda89	2025-12-18	fix / make obvious: recentReceiverId overwrite logic	track.c	take	core decode/output path (critical)	y			follow-up?	
+cd7b07eb0	2025-12-18	set recentReceiverIds for aircraft without position	track.c	take	core decode/output path (critical)	y				
+f4f7648cb	2025-12-18	incrementing version: 3.16.7	debian/changelog,version	skip	debian changelog metadata only					
+25b1409e0	2025-12-20	less noise about trackremovestale taking a bit of time	track.c	take	core decode/output path (critical)	y				
+71b4390c7	2025-12-21	api: fix out of bounds read	api.c	take	core decode/output path (critical)	y			follow-up?	
+130c1439c	2025-12-21	net_io: fix null deref when with proxy strings	net_io.c	take	core decode/output path (critical)	y			follow-up?	
+5141685f5	2025-12-21	net_io: fix asterix decoding fspec	net_io.c	take	core decode/output path (critical)	y			follow-up?	
+91346cb5a	2025-12-21	net_io: fix readAsterix length validation failure	net_io.c	take	core decode/output path (critical)	y			follow-up?	
+b05ebdafe	2025-12-21	incrementing version: 3.16.8	debian/changelog,version	skip	debian changelog metadata only					
+4295f84da	2025-12-22	ensure decodePlanefinder does not read past buffer	net_io.c	take	core decode/output path (critical)	y				
+26d7e0989	2025-12-22	api: filter_uuid: emit planes for a bit longer	api.c	take	core decode/output path (critical)	y				
+69d453825	2025-12-24	docker: use zstd compression	.github/workflows/docker.yaml	take	build/CI only; preserve ADSBx label+workflows | retag->take: build hunks reconciled by tip customization patch			tip-patch		
+14881d22a	2025-12-31	add macro to print current line	util.h	take	core code (non-critical) | debug/log output only	n				
+f0e2ed96c	2025-12-31	add debug mechanism for garbage counter incrementing	net_io.c	take	core decode/output path (critical)	y				
+1e3ba484e	2025-12-31	beast: don't assume garbage for long messages	net_io.c	take	core decode/output path (critical)	y				
+d85add5d2	2026-01-01	fixup encapsulated UAT msg length check	net_io.c	take	core decode/output path (critical)	y				
+ba52568d6	2026-01-01	beast: default disabled debugging for sender not flushing whole messages	net_io.c,net_io.h	take	core decode/output path (critical)	y				
+800aca053	2026-01-10	Fix early return in decodeBDS44 pressure scoring	comm_b.c	take	core decode/output path (critical)	y			follow-up?	
+bd95a8a3d	2026-01-17	detect bad tuners and log / make available in json	5 files: json_out.c,readsb.c,readsb.h,sdr_rtlsdr.c,stats.c	take	core decode/output path (critical)	y				
+7824553d0	2026-01-17	incrementing version: 3.16.9	debian/changelog,version	skip	debian changelog metadata only					
+5831f9109	2026-02-03	change default autogain parameters	README.md,readsb.c	take	core code (non-critical) | SDR autogain tuning; not unit-testable, validate on SDR build if used	n				
+a88e53b99	2026-02-28	fix up tat / oat missing from traces	json_out.c,track.c	take	core decode/output path (critical)	y			follow-up?	
+f31032a45	2026-02-28	incrementing version: 3.16.10	debian/changelog,version	skip	debian changelog metadata only					
+7d341c6be	2026-02-28	Fix addrtype_t out of bounds	readsb.h	take	core code (non-critical) | addrtype_t OOB fix; aircraft type output correctness	y			follow-up?	
+7daf43646	2026-04-04	ingest: limit position rate	5 files: net_io.c,net_io.h,readsb.c,readsb.h,track.c	take	core decode/output path (critical)	y				
+c2af85460	2026-04-04	docker: add with_uuids build	Dockerfile	take	build/CI only; preserve ADSBx label+workflows | retag->take: build hunks reconciled by tip customization patch			tip-patch		
+9f7071c89	2026-04-04	non transponder: lower priority	mode_s.c,readsb.h,toString.h,track.c	take	core decode/output path (critical)	y				
+9a9da7a14	2026-04-05	threadpool: add ifdef dependent debug prints	threadpool.c	take	core code (non-critical) | debug/log output only	n				
+eb635963c	2026-04-05	threadpool: add busy loop counting	threadpool.c	take	core code (non-critical) | debug/log output only	n				
+ba2fae14f	2026-04-05	threadpool: improve variable naming	threadpool.c	take	core code (non-critical) | cleanup/refactor; no behavior change	n				
+0dfa2aafa	2026-04-06	threadpool: use fetch_sub instead of compare exchange	threadpool.c	take	core code (non-critical) | perf/memory; no observable output change	n				
+542534546	2026-04-06	use madvise just in case for transparent hugepages	readsb.h	take	core code (non-critical) | perf/memory; no observable output change	n				
+15917d77a	2026-04-06	remove spurious unused declaration	readsb.h	take	core code (non-critical) | cleanup/refactor; no behavior change	n				
+4da537f6c	2026-04-06	incrementing version: 3.16.11	debian/changelog,version	skip	debian changelog metadata only					
+6ecea84fb	2026-04-08	Fix: wind assignment & duplicate check	track.c	take	core decode/output path (critical)	y			follow-up?	
+6d31c983c	2026-04-09	make hugepage handling better	aircraft.c,readsb.c,readsb.h	take	core decode/output path (critical)	y				
+4d6c614d7	2026-04-11	Refactor: update hugepage definitions and usage in memory allocation	aircraft.c,readsb.c,readsb.h	take	core decode/output path (critical)	y				
+062afb4df	2026-04-19	Add ?find_squawk API option	README-json.md,api.c,api.h	take	core decode/output path (critical)	y				
+caf2c5a6d	2026-04-26	filter_squawk: support list as well	README-json.md,api.c,api.h	take	core decode/output path (critical)	y				
+d38b903bb	2026-05-01	receiver json: indicate if replay is being written	json_out.c	take	core decode/output path (critical)	y				
+b8f00f86f	2026-05-04	add cpr repitition exception	track.c	take	core decode/output path (critical)	y				
+307a8554f	2026-05-04	incrementing version: 3.16.12	debian/changelog,version	skip	debian changelog metadata only					
+433a61cf6	2026-05-04	incrementing version: 3.16.13	debian/changelog,version	skip	debian changelog metadata only					
+ecb9f4f5c	2026-05-04	cpr repitition: fix issue with uat	track.c	take	core decode/output path (critical)	y			follow-up?	
+b80c737b4	2026-05-04	incrementing version: 3.16.14	debian/changelog,version	skip	debian changelog metadata only					
+04e88d9d5	2026-05-11	new option: --net-json-port-wind-triggered	help.h,readsb.c,readsb.h,track.c	take	core decode/output path (critical)	y				
+226ce8547	2026-05-12	wind triggered tcp json output: only emit when position is fresher than 2.5s	help.h,track.c	take	core decode/output path (critical)	y				
+05df27db9	2026-05-12	incrementing version: 3.16.15	debian/changelog,version	skip	debian changelog metadata only					
+b65ee05ff	2026-05-12	better git describe version in version strings	Makefile	take	build/CI only; preserve ADSBx label+workflows | retag->take: build hunks reconciled by tip customization patch			tip-patch		
+b499ecbd1	2026-05-13	remove unused variable	net_io.c	take	core decode/output path (critical)	y				
+0adaebb8d	2026-05-27	Add optional SBS RSSI field (field 23) using --devel=sbs_rssi	net_io.c,readsb.c,readsb.h,util.c	take	core decode/output path (critical)	y				
+e492f81c7	2026-06-07	Fix RSSI SBS output: buffer size and log10 clamp	net_io.c	take	core decode/output path (critical)	y			follow-up?	
+b2e7605da	2026-06-07	Cater for writing files to a dated sub-folder	readsb.c,readsb.h,util.c	take	core code (non-critical) | dated sub-folder output path feature	y				
+8c63e84e4	2026-06-07	Updates to build with SBS_RSSI=yes	Dockerfile	take	build/CI only; preserve ADSBx label+workflows | retag->take: build hunks reconciled by tip customization patch			tip-patch		
+cc0d09975	2026-06-07	Fix sign-extension in Asterix message length parsing	net_io.c	take	core decode/output path (critical)	y			follow-up?	
+0bfd0473d	2026-06-08	Add --devel=sbs_extra_fields: append RSSI and aircraft category to SBS output	net_io.c,readsb.c,readsb.h	take	core decode/output path (critical)	y				

--- a/tools/upstream-sync/refine.py
+++ b/tools/upstream-sync/refine.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+"""AX-936: resolve the needs_unit_test='?' rows (non-critical core code) to y/n.
+
+classify.py leaves '?' on core-code commits that don't match a critical-path
+pattern. This script applies a human-reviewed decision map: 'y' where the
+commit changes assertable behavior with a test home in the ADSBx suite, 'n'
+for SDR autogain tuning, terminal UI, help/docs text, perf/refactor, Apple
+build shims, and debug/log changes. Run after classify.py.
+"""
+import csv, os
+from collections import Counter
+
+LEDGER = os.path.join(os.path.dirname(os.path.abspath(__file__)), "commits-ledger.tsv")
+Y = "y"
+
+# sha9 -> (needs_unit_test, needs_devenv, note) -- assertable behavior + test home
+DEC = {
+    "1a4c123d2": (Y, "y", "exit-on-hang signaling; cover via test_lifecycle"),
+    "3da4c74de": (Y, "",  "new --devel=legacy_history output mode"),
+    "6ee23d772": (Y, "",  "uptime in stats output; test_stats_and_history"),
+    "85c087779": (Y, "",  "WMM2025 model: geomag_tests expected values MUST update"),
+    "7cbbbe51f": (Y, "",  "setLatLon affects position/distance output"),
+    "0e5dc1197": (Y, "",  "creates --write-json dir; test_output_formats/lifecycle"),
+    "2b5abcc6d": (Y, "",  "greatcircle distance calc change; util_tests"),
+    "8cac43bcd": (Y, "",  "getUptime no synthetic ts; stats output"),
+    "f743b90e7": (Y, "",  "ais_charset NUL-termination; ais_charset_tests"),
+    "7335e0c01": (Y, "",  "distance calc back to elliptical earth; util_tests"),
+    "079768749": (Y, "y", "synthetic clock/priority affects ifile replay determinism in tests"),
+    "7d341c6be": (Y, "",  "addrtype_t OOB fix; aircraft type output correctness"),
+    "b2e7605da": (Y, "",  "dated sub-folder output path feature"),
+}
+N_NOTES = {
+    "autogain": "SDR autogain tuning; not unit-testable, validate on SDR build if used",
+    "ui":       "viewadsb/interactive terminal UI; not in automated suite",
+    "help":     "help/README text only",
+    "perf":     "perf/memory; no observable output change",
+    "refactor": "cleanup/refactor; no behavior change",
+    "apple":    "Apple/OSX build-portability shim; n/a to Linux prod",
+    "beast":    "beast/SDR serial path; not unit-testable",
+    "debug":    "debug/log output only",
+    "testfix":  "fixes make test target itself; test plumbing not new coverage",
+}
+N_CAT = {
+    "62768aadb":"refactor","e62917e0d":"perf","d6932bb08":"debug","ae09ee115":"refactor",
+    "f40bd618d":"autogain","1e276882a":"autogain","2c51b73c5":"autogain","80fc54619":"autogain",
+    "8fd5acf09":"autogain","89fc77451":"autogain","b4bd2f5c6":"autogain","7be4ddf30":"autogain",
+    "15823dd47":"autogain","7c34ff39b":"autogain","e8de53682":"autogain","2b6338496":"help",
+    "fb8449754":"autogain","795d69a37":"beast","8d2c17718":"debug","21dd45e9e":"apple",
+    "81ef113b1":"debug","a5f3c4009":"apple","435bdb8c1":"autogain","5c32b8bc6":"refactor",
+    "b251391b5":"refactor","171caff26":"perf","6ec88bffc":"refactor","0ec418431":"debug",
+    "bbf446ad0":"help","3df53b3ab":"perf","46ad2fc16":"help","9e5d95f7c":"perf",
+    "5bf3030c9":"perf","6a9f6432c":"beast","ece78830a":"beast","d3eb56779":"perf",
+    "e5a4fe909":"autogain","3862d1d5a":"autogain","1ecee5743":"autogain","cd775cba7":"perf",
+    "85d434726":"autogain","b1487aca5":"autogain","451221d54":"autogain","dab71ee4a":"refactor",
+    "21d399deb":"refactor","25eb72f0d":"ui","4493ff430":"ui","f4d29c888":"ui",
+    "74f2d9d01":"ui","de952d873":"ui","b6c96747b":"ui","eaa4085fa":"ui","c77b06279":"ui",
+    "539e11d46":"ui","26d725d3e":"help","460c9fc6b":"debug","3852ad21e":"debug",
+    "83cfa54e1":"help","2d007af3c":"ui","97ba5e692":"perf","14881d22a":"debug",
+    "5831f9109":"autogain","9a9da7a14":"debug","eb635963c":"debug","ba2fae14f":"refactor",
+    "0dfa2aafa":"perf","542534546":"perf","15917d77a":"refactor","175bf2472":"testfix",
+}
+DEVENV_EXTRA = {"cd775cba7": ("y", " (validate default change in dev)")}
+
+rows = list(csv.DictReader(open(LEDGER), delimiter="\t"))
+cols = list(rows[0].keys())
+changed = 0
+for r in rows:
+    if r["needs_unit_test"] != "?":
+        continue
+    sha = r["sha"]
+    if sha in DEC:
+        ut, dev, note = DEC[sha]
+        r["needs_unit_test"] = ut
+        if dev: r["needs_devenv"] = dev
+        r["reason"] += " | " + note
+        changed += 1
+    elif sha in N_CAT:
+        r["needs_unit_test"] = "n"
+        r["reason"] += " | " + N_NOTES[N_CAT[sha]]
+        if sha in DEVENV_EXTRA:
+            r["needs_devenv"], extra = DEVENV_EXTRA[sha]
+            r["reason"] += extra
+        changed += 1
+    else:
+        print(f"!! unmapped '?' sha: {sha} {r['subject'][:50]}")
+
+# ---- commit-strategy pass ----
+# Our entire build customization is 3 isolated, test-neutral files. So we
+# revert it at the start of the walk, take upstream verbatim (clean patch-ids),
+# and re-apply the customization as a single tip commit. That turns build-only
+# "adapt" rows into patch-id-clean "take" rows whose build hunks are reconciled
+# by the tip patch -- only the debian SDR-profile commits remain true adapts.
+retagged = 0
+for r in rows:
+    if r["decision"] != "adapt":
+        continue
+    if "SDR build profile" in r["reason"]:
+        r["commit_strategy"] = "verify-packaging"  # take verbatim; verify dpkg-buildpackage -Prtlsdr output
+    else:
+        r["decision"] = "take"
+        r["commit_strategy"] = "tip-patch"  # ADSBx build customization re-applied in single tip commit
+        r["reason"] += " | retag->take: build hunks reconciled by tip customization patch"
+        retagged += 1
+
+with open(LEDGER, "w", newline="") as fh:
+    w = csv.DictWriter(fh, fieldnames=cols, delimiter="\t")
+    w.writeheader(); w.writerows(rows)
+
+dec = Counter(r["decision"] for r in rows)
+strat = Counter(r["commit_strategy"] for r in rows if r["commit_strategy"])
+c = Counter(r["needs_unit_test"] for r in rows if r["decision"] in ("take","adapt"))
+print(f"resolved {changed} '?' rows; remaining '?': {sum(1 for r in rows if r['needs_unit_test']=='?')}")
+print(f"retagged build adapts -> take: {retagged}")
+print(f"decision: take={dec['take']} adapt={dec['adapt']} skip={dec['skip']}")
+print(f"commit_strategy: {dict(strat)}")
+print(f"needs_unit_test across take+adapt: y={c['y']} n={c['n']}")


### PR DESCRIPTION
## Summary

Delivers the prep + test-coverage phase of AX-936 (reconcile the `ADSBexchange/readsb` fork up to upstream `wiedehopf/readsb`). The per-commit reconciliation walk is **deferred/shelved** — this PR brings the standalone-valuable groundwork onto `dev`:

- **Upstream-sync triage tooling** (`tools/upstream-sync/`): `classify.py` + `refine.py` (deterministic, re-runnable after each `git fetch upstream`) and `commits-ledger.tsv` triaging all 474 behind commits (363 take / 2 adapt / 109 skip).
- **+40 integration tests** (suite 90→130, all green) pinning readsb's current output contracts against the `3.14.1631` baseline: globe-index tiles, trace files, clients.json, receiver.json, aircraft.json field contracts, globe-history layout, state persistence, json_out streaming, DB enrichment / military classification, and prod-flag coverage drawn from the `adsbexchange-app` per-role configs.
- Coverage index in `tests/TEST_COVERAGE.md`.

## Impact

- Tests + tooling only — **no infrastructure, no application/runtime code changes**. The fork's behavior is unchanged.
- The new tests establish a regression baseline so the eventual cherry-pick walk can proceed safely.
- Triage tooling + ledger are reproducible, so the walk can be resumed from a current upstream fetch without re-triaging by hand.